### PR TITLE
Improve task dependencies and default task

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ application dependencies.  You can check `package.json` and `bower.json` to see 
 
 The project uses `gulp` to automate many processes in the development environment.
 
+### Default (no arguments)
+
+Running `gulp` without any arguments is the equivalent to running `gulp qa`, `gulp less` and `gulp watch`, as described
+below.
+
+    gulp
+
 ### Performing QA
 
 To run linter, code style checker and unit tests:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,6 +21,9 @@
 
     gulp.task(
         'qa:test',
+        [
+            'qa:lint'
+        ],
         function () {
             return gulp
                 .src('test/runner.html')
@@ -100,7 +103,9 @@
     gulp.task(
         'default',
         [
-            'qa'
+            'qa',
+            'less',
+            'watch'
         ]
     );
 }(


### PR DESCRIPTION
+ Make `qa:test` dependent on `qa:lint` so that the tests
  are only run if the linter does not return any errors.
+ Make the default task run `qa`, `less` and `watch`.
+ Add documentation about default task.
