### PR TITLE
RWAHS-308 Improve search config

### DIFF
--- a/public/app/config/env/development.js
+++ b/public/app/config/env/development.js
@@ -11,10 +11,10 @@
                 enableCORS = { xhrFields: { withCredentials: true } };
 
             return function () {
-                container.register('LibrarySearchService', searchService(simpleApiBaseUrl + '/library_search', enableCORS));
-                container.register('PhotographsSearchService', searchService(simpleApiBaseUrl + '/photographs_search', enableCORS));
-                container.register('MuseumSearchService', searchService(simpleApiBaseUrl + '/museum_search', enableCORS));
-                container.register('MemorialsSearchService', searchService(simpleApiBaseUrl + '/memorials_search', enableCORS));
+                container.register('LibrarySearchService', searchService(simpleApiBaseUrl + '/library_search', enableCORS, true));
+                container.register('PhotographsSearchService', searchService(simpleApiBaseUrl + '/photographs_search', enableCORS, true));
+                container.register('MuseumSearchService', searchService(simpleApiBaseUrl + '/museum_search', enableCORS, true));
+                container.register('MemorialsSearchService', searchService(simpleApiBaseUrl + '/memorials_search', enableCORS, true));
                 container.seal();
             };
         }

--- a/public/app/config/env/staging.js
+++ b/public/app/config/env/staging.js
@@ -11,10 +11,10 @@
                 enableCORS = { xhrFields: { withCredentials: true } };
 
             return function () {
-                container.register('LibrarySearchService', searchService(simpleApiBaseUrl + '/library_search', enableCORS));
-                container.register('PhotographsSearchService', searchService(simpleApiBaseUrl + '/photographs_search', enableCORS));
-                container.register('MuseumSearchService', searchService(simpleApiBaseUrl + '/museum_search', enableCORS));
-                container.register('MemorialsSearchService', searchService(simpleApiBaseUrl + '/memorials_search', enableCORS));
+                container.register('LibrarySearchService', searchService(simpleApiBaseUrl + '/library_search', enableCORS, true));
+                container.register('PhotographsSearchService', searchService(simpleApiBaseUrl + '/photographs_search', enableCORS, true));
+                container.register('MuseumSearchService', searchService(simpleApiBaseUrl + '/museum_search', enableCORS, true));
+                container.register('MemorialsSearchService', searchService(simpleApiBaseUrl + '/memorials_search', enableCORS, true));
                 container.seal();
             };
         }

--- a/public/app/config/search/library/resultFields.js
+++ b/public/app/config/search/library/resultFields.js
@@ -18,10 +18,13 @@
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
                             .append(_(JSON.parse(value))
-                                .drop()
+                                .reject(function (valueItem) {
+                                    return !valueItem;
+                                })
                                 .map(function (valueItem) {
                                     return $('<li></li>').text(valueItem);
                                 })
+                                .value()
                             )
                             .prop('outerHTML');
                     }
@@ -48,10 +51,13 @@
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
                             .append(_(JSON.parse(value))
-                                .drop()
+                                .reject(function (valueItem) {
+                                    return !valueItem;
+                                })
                                 .map(function (valueItem) {
                                     return $('<li></li>').text(valueItem);
                                 })
+                                .value()
                             )
                             .prop('outerHTML');
                     }

--- a/public/app/config/search/library/resultFields.js
+++ b/public/app/config/search/library/resultFields.js
@@ -4,9 +4,10 @@
     define(
         [
             'lodash',
-            'jquery'
+            'jquery',
+            'util/safelyParseJson'
         ],
-        function (_, $) {
+        function (_, $, parse) {
             return [
                 {
                     key: 'Title',
@@ -17,7 +18,7 @@
                     labelText: 'Author',
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
-                            .append(_(JSON.parse(value))
+                            .append(_(parse(value))
                                 .reject(function (valueItem) {
                                     return !valueItem;
                                 })
@@ -50,7 +51,7 @@
                     labelText: 'Subjects',
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
-                            .append(_(JSON.parse(value))
+                            .append(_(parse(value))
                                 .reject(function (valueItem) {
                                     return !valueItem;
                                 })

--- a/public/app/config/search/memorials/resultFields.js
+++ b/public/app/config/search/memorials/resultFields.js
@@ -22,6 +22,9 @@
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
                             .append(_(JSON.parse(value))
+                                .reject(function (valueItem) {
+                                    return !valueItem || !valueItem.CreatorType || !valueItem.Name;
+                                })
                                 .map(function (valueItem) {
                                     return $('<li></li>')
                                         .text(valueItem.Name)
@@ -49,10 +52,13 @@
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
                             .append(_(JSON.parse(value))
-                                .drop()
+                                .reject(function (valueItem) {
+                                    return !valueItem;
+                                })
                                 .map(function (valueItem) {
                                     return $('<li></li>').text(valueItem);
                                 })
+                                .value()
                             )
                             .prop('outerHTML');
                     }

--- a/public/app/config/search/memorials/resultFields.js
+++ b/public/app/config/search/memorials/resultFields.js
@@ -40,7 +40,14 @@
                     key: 'Location',
                     labelText: 'Location',
                     displayValue: function (value) {
-                        return _(parse(value)).drop().join(' &rArr; ');
+                        return _(parse(value))
+                            .drop()
+                            .map(function (hierarchyNodeItem, depth) {
+                                return depth === 0 ?
+                                    hierarchyNodeItem :
+                                _.repeat('&nbsp;', 2 * depth) + '&rArr; ' + hierarchyNodeItem;
+                            })
+                            .join('<br/>');
                     }
                 },
                 {

--- a/public/app/config/search/memorials/resultFields.js
+++ b/public/app/config/search/memorials/resultFields.js
@@ -4,9 +4,10 @@
     define(
         [
             'lodash',
-            'jquery'
+            'jquery',
+            'util/safelyParseJson'
         ],
-        function (_, $) {
+        function (_, $, parse) {
             return [
                 {
                     key: 'idno',
@@ -21,7 +22,7 @@
                     labelText: 'Creator',
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
-                            .append(_(JSON.parse(value))
+                            .append(_(parse(value))
                                 .reject(function (valueItem) {
                                     return !valueItem || !valueItem.CreatorType || !valueItem.Name;
                                 })
@@ -39,7 +40,7 @@
                     key: 'Location',
                     labelText: 'Location',
                     displayValue: function (value) {
-                        return _(JSON.parse(value)).drop().join(' &rArr; ');
+                        return _(parse(value)).drop().join(' &rArr; ');
                     }
                 },
                 {
@@ -51,7 +52,7 @@
                     labelText: 'Subjects',
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
-                            .append(_(JSON.parse(value))
+                            .append(_(parse(value))
                                 .reject(function (valueItem) {
                                     return !valueItem;
                                 })

--- a/public/app/config/search/museum/resultFields.js
+++ b/public/app/config/search/museum/resultFields.js
@@ -4,9 +4,10 @@
     define(
         [
             'lodash',
-            'jquery'
+            'jquery',
+            'util/safelyParseJson'
         ],
-        function (_, $) {
+        function (_, $, parse) {
             return [
                 {
                     key: 'type',
@@ -33,7 +34,7 @@
                     labelText: 'Subjects',
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
-                            .append(_(JSON.parse(value))
+                            .append(_(parse(value))
                                 .reject(function (valueItem) {
                                     return !valueItem;
                                 })
@@ -50,7 +51,7 @@
                     labelText: 'Classification',
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
-                            .append(_(JSON.parse(value))
+                            .append(_(parse(value))
                                 .map(function (valueItem) {
                                     return $('<li></li>').html(_(valueItem)
                                         .drop()

--- a/public/app/config/search/museum/resultFields.js
+++ b/public/app/config/search/museum/resultFields.js
@@ -34,10 +34,13 @@
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
                             .append(_(JSON.parse(value))
-                                .drop()
+                                .reject(function (valueItem) {
+                                    return !valueItem;
+                                })
                                 .map(function (valueItem) {
                                     return $('<li></li>').text(valueItem);
                                 })
+                                .value()
                             )
                             .prop('outerHTML');
                     }
@@ -49,8 +52,16 @@
                         return $('<ul class="list-unstyled"></ul>')
                             .append(_(JSON.parse(value))
                                 .map(function (valueItem) {
-                                    return $('<li></li>').html(_(valueItem).drop().join(' &rArr; '));
+                                    return $('<li></li>').html(_(valueItem)
+                                        .drop()
+                                        .map(function (hierarchyNodeItem, depth) {
+                                            return depth === 0 ?
+                                                hierarchyNodeItem :
+                                                _.repeat('&nbsp;', 2 * depth) + '&rArr; ' + hierarchyNodeItem;
+                                        })
+                                        .join('<br/>'));
                                 })
+                                .value()
                             )
                             .prop('outerHTML');
                     }

--- a/public/app/config/search/photographs/resultFields.js
+++ b/public/app/config/search/photographs/resultFields.js
@@ -18,6 +18,9 @@
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
                             .append(_(JSON.parse(value))
+                                .reject(function (valueItem) {
+                                    return !valueItem || !valueItem.CreatorType || !valueItem.Name;
+                                })
                                 .map(function (valueItem) {
                                     return $('<li></li>')
                                         .text(valueItem.Name)
@@ -54,10 +57,10 @@
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
                             .append(_(JSON.parse(value))
-                                .drop()
                                 .map(function (valueItem) {
                                     return $('<li></li>').text(valueItem);
                                 })
+                                .value()
                             )
                             .prop('outerHTML');
                     }

--- a/public/app/config/search/photographs/resultFields.js
+++ b/public/app/config/search/photographs/resultFields.js
@@ -4,9 +4,10 @@
     define(
         [
             'lodash',
-            'jquery'
+            'jquery',
+            'util/safelyParseJson'
         ],
-        function (_, $) {
+        function (_, $, parse) {
             return [
                 {
                     key: 'Title',
@@ -17,7 +18,7 @@
                     labelText: 'Creator',
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
-                            .append(_(JSON.parse(value))
+                            .append(_(parse(value))
                                 .reject(function (valueItem) {
                                     return !valueItem || !valueItem.CreatorType || !valueItem.Name;
                                 })
@@ -56,7 +57,7 @@
                     labelText: 'Subjects',
                     displayValue: function (value) {
                         return $('<ul class="list-unstyled"></ul>')
-                            .append(_(JSON.parse(value))
+                            .append(_(parse(value))
                                 .map(function (valueItem) {
                                     return $('<li></li>').text(valueItem);
                                 })

--- a/public/app/services/searchService.js
+++ b/public/app/services/searchService.js
@@ -7,7 +7,7 @@
             'jquery'
         ],
         function (_, $) {
-            return function (baseUrl, ajaxOptions) {
+            return function (baseUrl, ajaxOptions, noCache) {
                 var queryString;
 
                 queryString = function (parameters) {
@@ -19,7 +19,7 @@
 
                 return function (parameters, callback) {
                     $.ajax(_.merge({}, ajaxOptions, {
-                        url: baseUrl + '?q=' + queryString(parameters || {}),
+                        url: baseUrl + '?q=' + queryString(parameters || {}) + (noCache ? '&noCache=1' : ''),
                         success: function (result) {
                             if (!result.ok) {
                                 return callback(new Error('Invalid response received from server'));

--- a/public/app/util/safelyParseJson.js
+++ b/public/app/util/safelyParseJson.js
@@ -1,0 +1,20 @@
+(function () {
+    'use strict';
+
+    define(
+        [
+        ],
+        function () {
+            return function (string) {
+                try {
+                    return JSON.parse(string);
+                } catch (e) {
+                    if (console && typeof console.error === 'function') {
+                        console.error(e);
+                    }
+                    return '';
+                }
+            };
+        }
+    );
+}());

--- a/test/main.js
+++ b/test/main.js
@@ -76,7 +76,8 @@
                     'spec/ui/pages/search/SearchPage.spec',
                     'spec/ui/pages/search/SearchMapper.spec',
                     'spec/util/container.spec',
-                    'spec/util/router.spec'
+                    'spec/util/router.spec',
+                    'spec/util/safelyParseJson.spec'
                 ],
                 function () {
                     // See https://github.com/nathanboktae/mocha-phantomjs-core/issues/12

--- a/test/spec/services/searchService.spec.js
+++ b/test/spec/services/searchService.spec.js
@@ -174,6 +174,98 @@
                         });
                     });
                 });
+                describe('When invoked with valid parameters including `noCache`', function () {
+                    var service;
+                    beforeEach(function () {
+                        service = searchService('http://server.name/path/to/api', { foo: 'bar' }, true);
+                    });
+                    it('Returns a function', function () {
+                        expect(service).to.be.a('function');
+                    });
+                    describe('When the returned function is invoked', function () {
+                        describe('When AJAX calls are working correctly', function () {
+                            beforeEach(function () {
+                                sinon.stub($, 'ajax', function (params) {
+                                    params.success({
+                                        ok: true,
+                                        '1': 'first result',
+                                        '2': 'second result',
+                                        '3': 'third result'
+                                    });
+                                });
+                            });
+                            describe('When invoked with no parameters', function () {
+                                var serviceError, serviceResult;
+                                beforeEach(function (done) {
+                                    service(undefined, function (err, result) {
+                                        serviceError = err;
+                                        serviceResult = result;
+                                        done();
+                                    });
+                                });
+                                it('Makes an AJAX call', function () {
+                                    sinon.assert.calledOnce($.ajax);
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=&noCache=1');
+                                    expect($.ajax.args[0][0].foo).to.equal('bar');
+                                    expect($.ajax.args[0][0].success).to.be.a('function');
+                                    expect($.ajax.args[0][0].error).to.be.a('function');
+                                });
+                                it('Records a valid result', function () {
+                                    expect(serviceError).to.equal(undefined);
+                                    expect(serviceResult).to.be.an('array');
+                                    expect(serviceResult).to.have.length(3);
+                                });
+                            });
+                            describe('When invoked with one parameter', function () {
+                                var serviceError, serviceResult;
+                                beforeEach(function (done) {
+                                    service({ field: 'value' }, function (err, result) {
+                                        serviceError = err;
+                                        serviceResult = result;
+                                        done();
+                                    });
+                                });
+                                it('Makes an AJAX call', function () {
+                                    sinon.assert.calledOnce($.ajax);
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value)&noCache=1');
+                                    expect($.ajax.args[0][0].foo).to.equal('bar');
+                                    expect($.ajax.args[0][0].success).to.be.a('function');
+                                    expect($.ajax.args[0][0].error).to.be.a('function');
+                                });
+                                it('Records a valid result', function () {
+                                    expect(serviceError).to.equal(undefined);
+                                    expect(serviceResult).to.be.an('array');
+                                    expect(serviceResult).to.have.length(3);
+                                });
+                            });
+                            describe('When invoked with multiple parameters', function () {
+                                var serviceError, serviceResult;
+                                beforeEach(function (done) {
+                                    service({ field: 'value', another: 'search this' }, function (err, result) {
+                                        serviceError = err;
+                                        serviceResult = result;
+                                        done();
+                                    });
+                                });
+                                it('Makes an AJAX call', function () {
+                                    sinon.assert.calledOnce($.ajax);
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value) AND (another:search this)&noCache=1');
+                                    expect($.ajax.args[0][0].foo).to.equal('bar');
+                                    expect($.ajax.args[0][0].success).to.be.a('function');
+                                    expect($.ajax.args[0][0].error).to.be.a('function');
+                                });
+                                it('Records a valid result', function () {
+                                    expect(serviceError).to.equal(undefined);
+                                    expect(serviceResult).to.be.an('array');
+                                    expect(serviceResult).to.have.length(3);
+                                });
+                            });
+                            afterEach(function () {
+                                $.ajax.restore();
+                            });
+                        });
+                    });
+                });
             });
         }
     );

--- a/test/spec/util/safelyParseJson.spec.js
+++ b/test/spec/util/safelyParseJson.spec.js
@@ -1,0 +1,64 @@
+(function () {
+    'use strict';
+
+    define(
+        [
+            'chai',
+            'util/safelyParseJson'
+        ],
+        function (chai, safelyParseJson) {
+            var expect = chai.expect;
+
+            describe('The `safelyParseJson` module', function () {
+                it('Defines a function', function () {
+                    expect(safelyParseJson).to.be.a('function');
+                });
+                describe('When invoked with valid JSON', function () {
+                    describe('With a JSON string representing a string value', function () {
+                        it('Returns the string value', function () {
+                            expect(safelyParseJson('"JSON strings are quoted"')).to.equal('JSON strings are quoted');
+                        });
+                    });
+                    describe('With a JSON string representing a numeric value', function () {
+                        it('Returns the number value', function () {
+                            expect(safelyParseJson('42')).to.equal(42);
+                            expect(safelyParseJson('42.123')).to.equal(42.123);
+                        });
+                    });
+                    describe('With a JSON string representing a boolean value', function () {
+                        it('Returns the number value', function () {
+                            expect(safelyParseJson('true')).to.equal(true);
+                            expect(safelyParseJson('false')).to.equal(false);
+                        });
+                    });
+                    describe('With a JSON string representing an array', function () {
+                        it('Returns the array', function () {
+                            expect(safelyParseJson('["first",2,"third"]')).to.deep.equal([ 'first', 2, 'third' ]);
+                        });
+                    });
+                    describe('With a JSON string representing an object', function () {
+                        it('Returns the array', function () {
+                            expect(safelyParseJson('{ "foo": "bar", "meaning": 42 }')).to.deep.equal({ foo: 'bar', meaning: 42 });
+                        });
+                    });
+                });
+                describe('When invoked with a string that is not valid JSON', function () {
+                    it('Returns an empty string', function () {
+                        expect(safelyParseJson('')).to.equal('');
+                        expect(safelyParseJson('"mismatched quotes')).to.equal('');
+                        expect(safelyParseJson('unquoted text')).to.equal('');
+                        expect(safelyParseJson('mixed42')).to.equal('');
+                        expect(safelyParseJson('["array","missing","bracket"')).to.equal('');
+                        expect(safelyParseJson('["array","missing" "comma"]')).to.equal('');
+                        expect(safelyParseJson('["array","missing", quotes]')).to.equal('');
+                        expect(safelyParseJson('{"object": true, "missing": "brace"')).to.equal('');
+                        expect(safelyParseJson('{"object": true "missing": "comma"}')).to.equal('');
+                        expect(safelyParseJson('{"object": true, "missing" "colon"}')).to.equal('');
+                        expect(safelyParseJson('{"object": true, missing: "quotes on key"}')).to.equal('');
+                        expect(safelyParseJson('{"object": true, "missing": quotes on value}')).to.equal('');
+                    });
+                });
+            });
+        }
+    );
+}());


### PR DESCRIPTION
+ Handle invalid JSON by ignoring the value and continuing, rather than crashing.
+ Don't create `li` list items out of empty values (this is a side effect of the way the JSON is constructed on the API end, it will send an array consisting of an empty string when it should send an empty array).
+ Add missing calls to `_.value()`.
+ Display hierarchical values as (visual) hierarchies using `<br/>`, `&nbsp;` and `&rArr;`.
+ Support `noCache` parameter.