### PR TITLE
Remove unused `typeahead.js` dependency.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,6 @@
     "jquery": "^2.2.4",
     "lodash": "^4.13.1",
     "knockout": "^3.4.0",
-    "typeahead.js": "^0.11.1",
     "text": "requirejs-text#^2.0.15"
   }
 }

--- a/public/app/main.js
+++ b/public/app/main.js
@@ -14,8 +14,6 @@
             lodash: '../lib/lodash/lodash',
             jquery: '../lib/jquery/dist/jquery',
             bootstrap: '../lib/bootstrap/dist/js/bootstrap',
-            typeahead: '../lib/typeahead.js/dist/typeahead.jquery',
-            bloodhound: '../lib/typeahead.js/dist/bloodhound',
             page: '../lib/page/page',
 
             // Application modules
@@ -24,14 +22,6 @@
             services: 'services/',
             ui: 'ui/',
             util: 'util/'
-        },
-        shim: {
-            bloodhound: {
-                exports: 'Bloodhound'
-            },
-            typeahead: {
-                deps: [ 'jquery' ]
-            }
         }
     });
 

--- a/test/main.js
+++ b/test/main.js
@@ -17,8 +17,6 @@
             lodash: '../public/lib/lodash/lodash',
             jquery: '../public/lib/jquery/dist/jquery',
             bootstrap: '../public/lib/bootstrap/dist/js/bootstrap',
-            typeahead: '../public/lib/typeahead.js/dist/typeahead.jquery',
-            bloodhound: '../public/lib/typeahead.js/dist/bloodhound',
             page: '../public/lib/page/page',
 
             // Application modules
@@ -34,12 +32,6 @@
             fixtures: 'fixtures/'
         },
         shim: {
-            bloodhound: {
-                exports: 'Bloodhound'
-            },
-            typeahead: {
-                deps: [ 'jquery' ]
-            },
             mocha: {
                 init: function () {
                     // https://gist.github.com/michaelcox/3800736


### PR DESCRIPTION
This was annoying me for a while now that it was sitting around unused, but I just realised that we probably can't actually use typeahead anyway given the constraints (making an adapter for typeahead that works off the CA web services) and may actually cause performance issues on the CA end.