### PR TITLE
Add missing task dependencies.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,6 +59,9 @@
 
     gulp.task(
         'build:less',
+        [
+            'build:clean'
+        ],
         function () {
             return gulp
                 .src('public/less/main.less')
@@ -91,6 +94,9 @@
 
     gulp.task(
         'package:less',
+        [
+            'package:clean'
+        ],
         function () {
             if (environment === 'development') {
                 throw new Error('Cannot use "package" tasks in development environment');
@@ -107,6 +113,9 @@
 
     gulp.task(
         'package:javascript',
+        [
+            'package:clean'
+        ],
         function () {
             if (environment === 'development') {
                 throw new Error('Cannot use "package" tasks in development environment');
@@ -136,6 +145,9 @@
 
     gulp.task(
         'package:html',
+        [
+            'package:clean'
+        ],
         function () {
             if (environment === 'development') {
                 throw new Error('Cannot use "package" tasks in development environment');
@@ -150,6 +162,9 @@
 
     gulp.task(
         'package:images',
+        [
+            'package:clean'
+        ],
         function () {
             if (environment === 'development') {
                 throw new Error('Cannot use "package" tasks in development environment');


### PR DESCRIPTION
+ Previously, the `package:clean` task was not finishing
  before other `package:*` tasks were commencing.
+ This was a misconfiguration of the `gulp` tasks.
+ They are now all dependent on `package:clean`.
+ Similarly with `build:clean`.