### PR TITLE
Deploy task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.idea/
+/.awscache/
+/.awspublish-*
 /node_modules/
 /public/lib/
 /public/css/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -176,13 +176,26 @@
     );
 
     gulp.task(
+        'package:fonts',
+        [
+            'package:clean'
+        ],
+        function () {
+            return gulp
+                .src('public/lib/bootstrap/fonts/**/*')
+                .pipe(gulp.dest('dist/' + environment + '/lib/bootstrap/fonts'));
+        }
+    );
+
+    gulp.task(
         'package',
         [
             'package:clean',
             'package:less',
             'package:javascript',
             'package:html',
-            'package:images'
+            'package:images',
+            'package:fonts'
         ]
     );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,6 +181,9 @@
             'package:clean'
         ],
         function () {
+            if (environment === 'development') {
+                throw new Error('Cannot use "package" tasks in development environment');
+            }
             return gulp
                 .src('public/lib/bootstrap/fonts/**/*')
                 .pipe(gulp.dest('dist/' + environment + '/lib/bootstrap/fonts'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,6 +59,9 @@
 
     gulp.task(
         'build:less',
+        [
+            'build:clean'
+        ],
         function () {
             return gulp
                 .src('public/less/main.less')
@@ -91,6 +94,9 @@
 
     gulp.task(
         'package:less',
+        [
+            'package:clean'
+        ],
         function () {
             if (environment === 'development') {
                 throw new Error('Cannot use "package" tasks in development environment');
@@ -107,6 +113,9 @@
 
     gulp.task(
         'package:javascript',
+        [
+            'package:clean'
+        ],
         function () {
             if (environment === 'development') {
                 throw new Error('Cannot use "package" tasks in development environment');
@@ -136,6 +145,9 @@
 
     gulp.task(
         'package:html',
+        [
+            'package:clean'
+        ],
         function () {
             if (environment === 'development') {
                 throw new Error('Cannot use "package" tasks in development environment');
@@ -150,6 +162,9 @@
 
     gulp.task(
         'package:images',
+        [
+            'package:clean'
+        ],
         function () {
             if (environment === 'development') {
                 throw new Error('Cannot use "package" tasks in development environment');

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   },
   "homepage": "https://github.com/rwahs/research-frontend#readme",
   "devDependencies": {
+    "aws-sdk": "^2.3.17",
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
+    "gulp-awspublish": "^3.2.0",
     "gulp-connect": "^4.0.0",
     "gulp-header": "^1.8.2",
     "gulp-jscs": "^3.0.2",


### PR DESCRIPTION
Includes #13 and #14 

Adds a `deploy` task that publishes to S3.

Credentials go in `~/.aws/credentials`.

Note there is a `research-frontend-deploy` user with keys and no password, and a restricted policy, created for this purpose (same user for staging and UAT, can be discussed but doesn't affect the PR).  Keys are on G drive.
