### PR TITLE
Add missing dependencies in `gulpfile.js`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,7 +67,6 @@
     gulp.task(
         'build:less',
         [
-            'qa',
             'build:clean'
         ],
         function () {
@@ -83,7 +82,6 @@
     gulp.task(
         'build',
         [
-            'qa',
             'build:clean',
             'build:less'
         ]
@@ -91,6 +89,10 @@
 
     gulp.task(
         'package:clean',
+        [
+            'qa',
+            'build'
+        ],
         function (callback) {
             if (environment === 'development') {
                 throw new Error('Cannot use "package" tasks in development environment');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,6 +67,7 @@
     gulp.task(
         'build:less',
         [
+            'qa',
             'build:clean'
         ],
         function () {
@@ -82,6 +83,7 @@
     gulp.task(
         'build',
         [
+            'qa',
             'build:clean',
             'build:less'
         ]
@@ -102,6 +104,8 @@
     gulp.task(
         'package:less',
         [
+            'qa',
+            'build',
             'package:clean'
         ],
         function () {
@@ -121,6 +125,8 @@
     gulp.task(
         'package:javascript',
         [
+            'qa',
+            'build',
             'package:clean'
         ],
         function () {
@@ -158,6 +164,8 @@
     gulp.task(
         'package:html',
         [
+            'qa',
+            'build',
             'package:clean'
         ],
         function () {
@@ -185,6 +193,8 @@
     gulp.task(
         'package:images',
         [
+            'qa',
+            'build',
             'package:clean'
         ],
         function () {
@@ -200,6 +210,8 @@
     gulp.task(
         'package:fonts',
         [
+            'qa',
+            'build',
             'package:clean'
         ],
         function () {
@@ -215,6 +227,8 @@
     gulp.task(
         'package:robotstxt',
         [
+            'qa',
+            'build',
             'package:clean'
         ],
         function () {
@@ -231,6 +245,8 @@
     gulp.task(
         'package',
         [
+            'qa',
+            'build',
             'package:clean',
             'package:less',
             'package:javascript',
@@ -244,6 +260,8 @@
     gulp.task(
         'deploy',
         [
+            'qa',
+            'build',
             'package'
         ],
         function () {


### PR DESCRIPTION
This ensures that both `qa` and `build` are successful before allowing `package` or `deploy` to proceed.

Note that `qa` is intentionally not required for `build` because `build` is actually only related to LESS files at this stage; javascript is processed in `package`.