### PR TITLE
RWAHS-467 Fix quick search

### DIFF
--- a/public/app/models/query/Condition.js
+++ b/public/app/models/query/Condition.js
@@ -21,31 +21,19 @@
                     return [
                         {
                             key: 'contains',
-                            label: 'contains',
-                            queryFormat: function (value) {
-                                return '"' + value + '"';
-                            }
+                            labelText: 'contains'
                         },
                         {
-                            key: '!contains',
-                            label: 'does not contain',
-                            queryFormat: function (value) {
-                                return '-"' + value + '"';
-                            }
+                            key: 'notContains',
+                            labelText: 'does not contain'
                         },
                         {
-                            key: 'starts',
-                            label: 'starts with',
-                            queryFormat: function (value) {
-                                return '"' + value + '"*';
-                            }
+                            key: 'startsWith',
+                            labelText: 'starts with'
                         },
                         {
-                            key: '!starts',
-                            label: 'does not start with',
-                            queryFormat: function (value) {
-                                return '-"' + value + '"*';
-                            }
+                            key: 'notStartsWith',
+                            labelText: 'does not start with'
                         }
                     ];
                 });

--- a/public/app/models/query/Group.js
+++ b/public/app/models/query/Group.js
@@ -18,12 +18,12 @@
                 this.operators = ko.pureComputed(function () {
                     return [
                         {
-                            label: 'and',
-                            value: 'AND'
+                            key: 'AND',
+                            labelText: 'and'
                         },
                         {
-                            label: 'or',
-                            value: 'OR'
+                            key: 'OR',
+                            labelText: 'or'
                         }
                     ];
                 });

--- a/public/app/ui/components/search/queryBuilder/query-builder.html
+++ b/public/app/ui/components/search/queryBuilder/query-builder.html
@@ -5,7 +5,7 @@
 <script type="text/html" id="condition-template">
     <div class="condition">
         <select data-bind="options: fields, optionsCaption: '', optionsText: 'labelText', optionsValue: 'key', value: selectedField" class="form-control field styled-select"></select>
-        <select data-bind="options: comparators, optionsCaption: '', optionsText: 'label', optionsValue: 'key', value: selectedComparator" class="form-control comparator styled-select"></select>
+        <select data-bind="options: comparators, optionsCaption: '', optionsText: 'labelText', optionsValue: 'key', value: selectedComparator" class="form-control comparator styled-select"></select>
         <input type="text" data-bind="textInput: value" class="form-control condition-value" />
         <button class="btn btn-danger btn-xs pull-right" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-minus-sign"></span> Remove</button>
     </div>
@@ -14,7 +14,7 @@
 <script type="text/html" id="group-template">
     <div class="group">
         <div class="group-controls">
-            <select data-bind="options: operators, optionsText: 'label', optionsValue: 'value', value: selectedOperator" class="form-control operator styled-select"></select>
+            <select data-bind="options: operators, optionsText: 'labelText', optionsValue: 'key', value: selectedOperator" class="form-control operator styled-select"></select>
             <div class="pull-right">
                 <button class="btn btn-xs btn-success" data-bind="click: addCondition"><span class="glyphicon glyphicon-plus-sign"></span> Add Condition</button>
                 <!-- ko if: allowChildren -->

--- a/public/app/ui/components/search/quick/QuickSearchComponent.js
+++ b/public/app/ui/components/search/quick/QuickSearchComponent.js
@@ -5,9 +5,10 @@
         [
             'lodash',
             'knockout',
-            'config/routes'
+            'config/routes',
+            'util/convertBasicSearch'
         ],
-        function (_, ko, routes) {
+        function (_, ko, routes, convertBasicSearch) {
             return function (parameters) {
                 if (!parameters) {
                     throw new Error('QuickSearchComponent missing parameter map.');
@@ -26,7 +27,7 @@
                     if (this.preventSubmit()) {
                         return false;
                     }
-                    routes.pushState(routes.searchUrlFor(parameters.searchBaseUrl, { query: this.searchText() }), true);
+                    routes.pushState(routes.searchUrlFor(parameters.searchBaseUrl, { query: JSON.stringify(convertBasicSearch('_fulltext', this.searchText())) }), true);
                     return false;
                 };
             };

--- a/public/app/ui/pages/search/SearchPage.js
+++ b/public/app/ui/pages/search/SearchPage.js
@@ -119,7 +119,7 @@
                     }
                 };
 
-                this.ready = function (callback) {
+                this.ready = function (element, callback) {
                     overlay.loading(false);
                     callback();
                 };

--- a/public/app/util/convertBasicSearch.js
+++ b/public/app/util/convertBasicSearch.js
@@ -1,0 +1,26 @@
+(function () {
+    'use strict';
+
+    define(
+        [
+            'lodash'
+        ],
+        function (_) {
+            return function (field, text) {
+                return text.length === 0 ? undefined : {
+                    operator: 'AND',
+                    children: _.map(
+                        text.split(/\s+/),
+                        function (term) {
+                            return {
+                                field: field,
+                                comparator: 'contains',
+                                value: term
+                            };
+                        }
+                    )
+                };
+            };
+        }
+    );
+}());

--- a/test/spec/models/query/Group.spec.js
+++ b/test/spec/models/query/Group.spec.js
@@ -40,7 +40,7 @@
                     });
                     it('Exposes the correct default values', function () {
                         expect(group.children()).to.have.length(1);
-                        expect(group.selectedOperator().value).to.equal('AND');
+                        expect(group.selectedOperator().key).to.equal('AND');
                     });
                     it('Calculates the correct depth', function () {
                         expect(group.depth()).to.equal(0);
@@ -73,7 +73,7 @@
                     });
                     it('Exposes the correct default values', function () {
                         expect(group.children()).to.have.length(1);
-                        expect(group.selectedOperator().value).to.equal('AND');
+                        expect(group.selectedOperator().key).to.equal('AND');
                     });
                     it('Calculates the correct depth', function () {
                         expect(group.depth()).to.equal(1);

--- a/test/spec/services/searchService.spec.js
+++ b/test/spec/services/searchService.spec.js
@@ -60,67 +60,203 @@
                                 });
                             });
                             describe('When invoked with one parameter', function () {
-                                var parameters, serviceError, serviceResult;
-                                beforeEach(function (done) {
-                                    parameters = {
-                                        operator: 'AND',
-                                        children: [
-                                            {
-                                                field: 'field',
-                                                value: 'value'
-                                            }
-                                        ]
-                                    };
-                                    service(parameters, function (err, result) {
-                                        serviceError = err;
-                                        serviceResult = result;
-                                        done();
+                                describe('With the "contains" comparator', function () {
+                                    var parameters, serviceError, serviceResult;
+                                    beforeEach(function (done) {
+                                        parameters = {
+                                            operator: 'AND',
+                                            children: [
+                                                {
+                                                    field: 'field',
+                                                    comparator: 'contains',
+                                                    value: 'value'
+                                                }
+                                            ]
+                                        };
+                                        service(parameters, function (err, result) {
+                                            serviceError = err;
+                                            serviceResult = result;
+                                            done();
+                                        });
+                                    });
+                                    it('Makes an AJAX call', function () {
+                                        sinon.assert.calledOnce($.ajax);
+                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value")');
+                                        expect($.ajax.args[0][0].success).to.be.a('function');
+                                        expect($.ajax.args[0][0].error).to.be.a('function');
+                                    });
+                                    it('Records a valid result', function () {
+                                        expect(serviceError).to.equal(undefined);
+                                        expect(serviceResult).to.be.an('array');
+                                        expect(serviceResult).to.have.length(3);
                                     });
                                 });
-                                it('Makes an AJAX call', function () {
-                                    sinon.assert.calledOnce($.ajax);
-                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value)');
-                                    expect($.ajax.args[0][0].success).to.be.a('function');
-                                    expect($.ajax.args[0][0].error).to.be.a('function');
+                                describe('With the "notContains" comparator', function () {
+                                    var parameters, serviceError, serviceResult;
+                                    beforeEach(function (done) {
+                                        parameters = {
+                                            operator: 'AND',
+                                            children: [
+                                                {
+                                                    field: 'field',
+                                                    comparator: 'notContains',
+                                                    value: 'value'
+                                                }
+                                            ]
+                                        };
+                                        service(parameters, function (err, result) {
+                                            serviceError = err;
+                                            serviceResult = result;
+                                            done();
+                                        });
+                                    });
+                                    it('Makes an AJAX call', function () {
+                                        sinon.assert.calledOnce($.ajax);
+                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=!(field:"value")');
+                                        expect($.ajax.args[0][0].success).to.be.a('function');
+                                        expect($.ajax.args[0][0].error).to.be.a('function');
+                                    });
+                                    it('Records a valid result', function () {
+                                        expect(serviceError).to.equal(undefined);
+                                        expect(serviceResult).to.be.an('array');
+                                        expect(serviceResult).to.have.length(3);
+                                    });
                                 });
-                                it('Records a valid result', function () {
-                                    expect(serviceError).to.equal(undefined);
-                                    expect(serviceResult).to.be.an('array');
-                                    expect(serviceResult).to.have.length(3);
+                                describe('With the "startsWith" comparator', function () {
+                                    var parameters, serviceError, serviceResult;
+                                    beforeEach(function (done) {
+                                        parameters = {
+                                            operator: 'AND',
+                                            children: [
+                                                {
+                                                    field: 'field',
+                                                    comparator: 'startsWith',
+                                                    value: 'value'
+                                                }
+                                            ]
+                                        };
+                                        service(parameters, function (err, result) {
+                                            serviceError = err;
+                                            serviceResult = result;
+                                            done();
+                                        });
+                                    });
+                                    it('Makes an AJAX call', function () {
+                                        sinon.assert.calledOnce($.ajax);
+                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value"*)');
+                                        expect($.ajax.args[0][0].success).to.be.a('function');
+                                        expect($.ajax.args[0][0].error).to.be.a('function');
+                                    });
+                                    it('Records a valid result', function () {
+                                        expect(serviceError).to.equal(undefined);
+                                        expect(serviceResult).to.be.an('array');
+                                        expect(serviceResult).to.have.length(3);
+                                    });
+                                });
+                                describe('With the "notStartsWith" comparator', function () {
+                                    var parameters, serviceError, serviceResult;
+                                    beforeEach(function (done) {
+                                        parameters = {
+                                            operator: 'AND',
+                                            children: [
+                                                {
+                                                    field: 'field',
+                                                    comparator: 'notStartsWith',
+                                                    value: 'value'
+                                                }
+                                            ]
+                                        };
+                                        service(parameters, function (err, result) {
+                                            serviceError = err;
+                                            serviceResult = result;
+                                            done();
+                                        });
+                                    });
+                                    it('Makes an AJAX call', function () {
+                                        sinon.assert.calledOnce($.ajax);
+                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=!(field:"value"*)');
+                                        expect($.ajax.args[0][0].success).to.be.a('function');
+                                        expect($.ajax.args[0][0].error).to.be.a('function');
+                                    });
+                                    it('Records a valid result', function () {
+                                        expect(serviceError).to.equal(undefined);
+                                        expect(serviceResult).to.be.an('array');
+                                        expect(serviceResult).to.have.length(3);
+                                    });
                                 });
                             });
                             describe('When invoked with multiple parameters', function () {
-                                var parameters, serviceError, serviceResult;
-                                beforeEach(function (done) {
-                                    parameters = {
-                                        operator: 'AND',
-                                        children: [
-                                            {
-                                                field: 'field',
-                                                value: 'value'
-                                            },
-                                            {
-                                                field: 'another',
-                                                value: 'search this'
-                                            }
-                                        ]
-                                    };
-                                    service(parameters, function (err, result) {
-                                        serviceError = err;
-                                        serviceResult = result;
-                                        done();
+                                describe('With the "AND" operator', function () {
+                                    var parameters, serviceError, serviceResult;
+                                    beforeEach(function (done) {
+                                        parameters = {
+                                            operator: 'AND',
+                                            children: [
+                                                {
+                                                    field: 'field',
+                                                    comparator: 'contains',
+                                                    value: 'value'
+                                                },
+                                                {
+                                                    field: 'another',
+                                                    comparator: 'notContains',
+                                                    value: 'search this'
+                                                }
+                                            ]
+                                        };
+                                        service(parameters, function (err, result) {
+                                            serviceError = err;
+                                            serviceResult = result;
+                                            done();
+                                        });
+                                    });
+                                    it('Makes an AJAX call', function () {
+                                        sinon.assert.calledOnce($.ajax);
+                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value") AND !(another:"search this")');
+                                        expect($.ajax.args[0][0].success).to.be.a('function');
+                                        expect($.ajax.args[0][0].error).to.be.a('function');
+                                    });
+                                    it('Records a valid result', function () {
+                                        expect(serviceError).to.equal(undefined);
+                                        expect(serviceResult).to.be.an('array');
+                                        expect(serviceResult).to.have.length(3);
                                     });
                                 });
-                                it('Makes an AJAX call', function () {
-                                    sinon.assert.calledOnce($.ajax);
-                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value) AND (another:search this)');
-                                    expect($.ajax.args[0][0].success).to.be.a('function');
-                                    expect($.ajax.args[0][0].error).to.be.a('function');
-                                });
-                                it('Records a valid result', function () {
-                                    expect(serviceError).to.equal(undefined);
-                                    expect(serviceResult).to.be.an('array');
-                                    expect(serviceResult).to.have.length(3);
+                                describe('With the "OR" operator', function () {
+                                    var parameters, serviceError, serviceResult;
+                                    beforeEach(function (done) {
+                                        parameters = {
+                                            operator: 'OR',
+                                            children: [
+                                                {
+                                                    field: 'field',
+                                                    comparator: 'startsWith',
+                                                    value: 'value'
+                                                },
+                                                {
+                                                    field: 'another',
+                                                    comparator: 'startsWith',
+                                                    value: 'search this'
+                                                }
+                                            ]
+                                        };
+                                        service(parameters, function (err, result) {
+                                            serviceError = err;
+                                            serviceResult = result;
+                                            done();
+                                        });
+                                    });
+                                    it('Makes an AJAX call', function () {
+                                        sinon.assert.calledOnce($.ajax);
+                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value"*) OR (another:"search this"*)');
+                                        expect($.ajax.args[0][0].success).to.be.a('function');
+                                        expect($.ajax.args[0][0].error).to.be.a('function');
+                                    });
+                                    it('Records a valid result', function () {
+                                        expect(serviceError).to.equal(undefined);
+                                        expect(serviceResult).to.be.an('array');
+                                        expect(serviceResult).to.have.length(3);
+                                    });
                                 });
                             });
                         });
@@ -196,6 +332,7 @@
                                         children: [
                                             {
                                                 field: 'field',
+                                                comparator: 'contains',
                                                 value: 'value'
                                             }
                                         ]
@@ -208,7 +345,7 @@
                                 });
                                 it('Makes an AJAX call', function () {
                                     sinon.assert.calledOnce($.ajax);
-                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value)');
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value")');
                                     expect($.ajax.args[0][0].foo).to.equal('bar');
                                     expect($.ajax.args[0][0].success).to.be.a('function');
                                     expect($.ajax.args[0][0].error).to.be.a('function');
@@ -227,10 +364,12 @@
                                         children: [
                                             {
                                                 field: 'field',
+                                                comparator: 'contains',
                                                 value: 'value'
                                             },
                                             {
                                                 field: 'another',
+                                                comparator: 'contains',
                                                 value: 'search this'
                                             }
                                         ]
@@ -243,7 +382,7 @@
                                 });
                                 it('Makes an AJAX call', function () {
                                     sinon.assert.calledOnce($.ajax);
-                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value) AND (another:search this)');
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value") AND (another:"search this")');
                                     expect($.ajax.args[0][0].foo).to.equal('bar');
                                     expect($.ajax.args[0][0].success).to.be.a('function');
                                     expect($.ajax.args[0][0].error).to.be.a('function');
@@ -300,6 +439,7 @@
                                         children: [
                                             {
                                                 field: 'field',
+                                                comparator: 'contains',
                                                 value: 'value'
                                             }
                                         ]
@@ -312,7 +452,7 @@
                                 });
                                 it('Makes an AJAX call', function () {
                                     sinon.assert.calledOnce($.ajax);
-                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value)&noCache=1');
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value")&noCache=1');
                                     expect($.ajax.args[0][0].success).to.be.a('function');
                                     expect($.ajax.args[0][0].error).to.be.a('function');
                                 });
@@ -330,10 +470,12 @@
                                         children: [
                                             {
                                                 field: 'field',
+                                                comparator: 'contains',
                                                 value: 'value'
                                             },
                                             {
                                                 field: 'another',
+                                                comparator: 'contains',
                                                 value: 'search this'
                                             }
                                         ]
@@ -346,7 +488,7 @@
                                 });
                                 it('Makes an AJAX call', function () {
                                     sinon.assert.calledOnce($.ajax);
-                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value) AND (another:search this)&noCache=1');
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value") AND (another:"search this")&noCache=1');
                                     expect($.ajax.args[0][0].success).to.be.a('function');
                                     expect($.ajax.args[0][0].error).to.be.a('function');
                                 });
@@ -402,6 +544,7 @@
                                         children: [
                                             {
                                                 field: 'field',
+                                                comparator: 'contains',
                                                 value: 'value'
                                             }
                                         ]
@@ -414,7 +557,7 @@
                                 });
                                 it('Makes an AJAX call', function () {
                                     sinon.assert.calledOnce($.ajax);
-                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value)');
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value")');
                                     expect($.ajax.args[0][0].success).to.be.a('function');
                                     expect($.ajax.args[0][0].error).to.be.a('function');
                                 });
@@ -432,10 +575,12 @@
                                         children: [
                                             {
                                                 field: 'field',
+                                                comparator: 'contains',
                                                 value: 'value'
                                             },
                                             {
                                                 field: 'another',
+                                                comparator: 'contains',
                                                 value: 'search this'
                                             }
                                         ]
@@ -448,7 +593,7 @@
                                 });
                                 it('Makes an AJAX call', function () {
                                     sinon.assert.calledOnce($.ajax);
-                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value) AND (another:search this)');
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value") AND (another:"search this")');
                                     expect($.ajax.args[0][0].success).to.be.a('function');
                                     expect($.ajax.args[0][0].error).to.be.a('function');
                                 });
@@ -504,6 +649,7 @@
                                         children: [
                                             {
                                                 field: 'field',
+                                                comparator: 'contains',
                                                 value: 'value'
                                             }
                                         ]
@@ -516,7 +662,7 @@
                                 });
                                 it('Makes an AJAX call', function () {
                                     sinon.assert.calledOnce($.ajax);
-                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value)&limit=42');
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value")&limit=42');
                                     expect($.ajax.args[0][0].success).to.be.a('function');
                                     expect($.ajax.args[0][0].error).to.be.a('function');
                                 });
@@ -534,10 +680,12 @@
                                         children: [
                                             {
                                                 field: 'field',
+                                                comparator: 'contains',
                                                 value: 'value'
                                             },
                                             {
                                                 field: 'another',
+                                                comparator: 'contains',
                                                 value: 'search this'
                                             }
                                         ]
@@ -550,7 +698,7 @@
                                 });
                                 it('Makes an AJAX call', function () {
                                     sinon.assert.calledOnce($.ajax);
-                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:value) AND (another:search this)&limit=42');
+                                    expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value") AND (another:"search this")&limit=42');
                                     expect($.ajax.args[0][0].success).to.be.a('function');
                                     expect($.ajax.args[0][0].error).to.be.a('function');
                                 });

--- a/test/spec/ui/components/search/quick/QuickSearchComponent.spec.js
+++ b/test/spec/ui/components/search/quick/QuickSearchComponent.spec.js
@@ -69,7 +69,7 @@
                             });
                             it('Navigates to the correct URL', function () {
                                 expect(routes.pushState.callCount).to.equal(1);
-                                expect(routes.pushState.getCall(0).args).to.deep.equal([ '/collection/search?query=some%20query', true ]);
+                                expect(routes.pushState.getCall(0).args).to.deep.equal([ '/collection/search?query=' + encodeURIComponent('{"operator":"AND","children":[{"field":"_fulltext","comparator":"contains","value":"some"},{"field":"_fulltext","comparator":"contains","value":"query"}]}'), true ]);
                             });
                         });
                         afterEach(function () {


### PR DESCRIPTION
Based on #57 please merge that one first.

Make `QuickSearchComponent` generate queries that actually work.

+ The query format was changed, but `QuickSearchComponent` was never updated to correspond.
+ Therefore quick search was not working.
+ This fixes the issue by updating `QuickSearchComponent` to the new format, utilising `convertBasicSearch`.
