### PR TITLE
Clean up search results.

### DIFF
--- a/public/app/config/collections/library/searchResultFields.js
+++ b/public/app/config/collections/library/searchResultFields.js
@@ -50,7 +50,7 @@
             },
             {
                 key: 'PublicationType',
-                labelText: 'Type',
+                labelText: 'Publication Type',
                 sort: true
             }
         ];

--- a/public/app/config/collections/museum/searchResultFields.js
+++ b/public/app/config/collections/museum/searchResultFields.js
@@ -29,7 +29,7 @@
                 sort: true
             },
             {
-                key: 'Dates',
+                key: 'ItemDates',
                 labelText: 'Dates',
                 sort: true
             },
@@ -41,17 +41,6 @@
             {
                 key: 'MakersMarks',
                 labelText: 'Makers Marks'
-            },
-            {
-                key: 'Classification',
-                labelText: 'Classification',
-                parse: true,
-                skipNested: 1,
-                filter: true,
-                display: 'hierarchy-list',
-                sort: function (value) {
-                    return value.length > 0 && value[0].length > 0 ? value[0].join(' / ') : undefined;
-                }
             }
         ];
     });

--- a/test/spec/config/collections/library/searchResultFields.spec.js
+++ b/test/spec/config/collections/library/searchResultFields.spec.js
@@ -60,7 +60,7 @@
                 });
                 it('Defines the `PublicationType` field', function () {
                     var publicationTypeField = _.find(searchResultFields, { key: 'PublicationType' });
-                    expect(publicationTypeField.labelText).to.equal('Type');
+                    expect(publicationTypeField.labelText).to.equal('Publication Type');
                     expect(publicationTypeField.sort).to.equal(true);
                 });
             });

--- a/test/spec/config/collections/museum/searchResultFields.spec.js
+++ b/test/spec/config/collections/museum/searchResultFields.spec.js
@@ -13,7 +13,7 @@
             describe('The `museum/searchResultFields` module', function () {
                 it('Defines a static array', function () {
                     expect(searchResultFields).to.be.an('array');
-                    expect(searchResultFields).to.have.length(9);
+                    expect(searchResultFields).to.have.length(8);
                 });
                 it('Defines the `MediaThumbnail` field', function () {
                     var mediaField = _.find(searchResultFields, { key: 'MediaThumbnail' });
@@ -40,8 +40,8 @@
                     expect(itemNameField.labelText).to.equal('Item Name');
                     expect(itemNameField.sort).to.equal(true);
                 });
-                it('Defines the `Dates` field', function () {
-                    var datesField = _.find(searchResultFields, { key: 'Dates' });
+                it('Defines the `ItemDates` field', function () {
+                    var datesField = _.find(searchResultFields, { key: 'ItemDates' });
                     expect(datesField.labelText).to.equal('Dates');
                     expect(datesField.sort).to.equal(true);
                 });
@@ -53,15 +53,6 @@
                 it('Defines the `MakersMarks` field', function () {
                     var makersMarksField = _.find(searchResultFields, { key: 'MakersMarks' });
                     expect(makersMarksField.labelText).to.equal('Makers Marks');
-                });
-                it('Defines the `Classification` field', function () {
-                    var classificationField = _.find(searchResultFields, { key: 'Classification' });
-                    expect(classificationField.labelText).to.equal('Classification');
-                    expect(classificationField.parse).to.equal(true);
-                    expect(classificationField.skipNested).to.equal(1);
-                    expect(classificationField.filter).to.equal(true);
-                    expect(classificationField.display).to.equal('hierarchy-list');
-                    expect(_.isFunction(classificationField.sort)).to.equal(true);
                 });
             });
         }


### PR DESCRIPTION
+ Improve label text for `PublicationDate`.
+ Use correct key for `ItemDates`.
+ Remove unused `Classification`.