### PR TITLE
Display tabs in mobile view

### DIFF
--- a/public/app/ui/shell.html
+++ b/public/app/ui/shell.html
@@ -1,6 +1,6 @@
 <div id="shell">
     <header class="navbar navbar-inverse navbar-static-top">
-        <div id="cross-site" class="nav-tabs navbar-collapse collapse">
+        <div id="cross-site" class="nav-tabs navbar-collapse">
             <div class="container" role="navigation">
                 <ul class="nav nav-tabs">
                     <li role="presentation"><a href="https://www.histwest.org.au/" class="cross-site-link">Website</a></li>

--- a/public/less/tweaks.less
+++ b/public/less/tweaks.less
@@ -3,6 +3,7 @@
 html {
     position: relative;
     min-height: 100%;
+    min-width: 300px;
 }
 
 p, li, dt, dd, td, th, details, button, form, a, div, details {


### PR DESCRIPTION
Remove `collapse` class.

Also, prevent broken layout of tabs and header in mobile view <300px, by setting minimum width of `html` element.
