### PR TITLE
Make `enter` key submit search rather than adding a condition.

### DIFF
--- a/public/app/ui/components/search/queryBuilder/QueryBuilderComponent.js
+++ b/public/app/ui/components/search/queryBuilder/QueryBuilderComponent.js
@@ -4,16 +4,20 @@
 
     define(
         [
+            'lodash',
             'knockout',
             'models/query/Group',
             'models/query/Condition'
         ],
-        function (ko, Group, Condition) {
+        function (_, ko, Group, Condition) {
             return function (parameters) {
                 var root;
 
                 if (!parameters.queryObservable || !ko.isObservable(parameters.queryObservable)) {
                     throw new Error('QueryBuilderComponent missing or invalid required parameter: `queryObservable`.');
+                }
+                if (!parameters.submit || !_.isFunction(parameters.submit)) {
+                    throw new Error('QueryBuilderComponent missing or invalid required parameter: `submit`.');
                 }
                 if (!parameters.fields || parameters.fields().length === 0) {
                     throw new Error('QueryBuilderComponent missing required parameter: `fields`.');
@@ -45,6 +49,14 @@
                     if (node instanceof Condition) {
                         return 'condition-template';
                     }
+                };
+
+                this.keypressHandler = function (ignore, evt) {
+                    if (evt.keyCode === 13) {
+                        parameters.submit();
+                        return false;
+                    }
+                    return true;
                 };
             };
         }

--- a/public/app/ui/components/search/queryBuilder/query-builder.html
+++ b/public/app/ui/components/search/queryBuilder/query-builder.html
@@ -6,7 +6,7 @@
     <div class="condition">
         <select data-bind="options: fields, optionsCaption: '', optionsText: 'labelText', optionsValue: 'key', value: selectedField" class="form-control field styled-select"></select>
         <select data-bind="options: comparators, optionsCaption: '', optionsText: 'labelText', optionsValue: 'key', value: selectedComparator" class="form-control comparator styled-select"></select>
-        <input type="text" data-bind="textInput: value" class="form-control condition-value" />
+        <input type="text" data-bind="textInput: value, event: { keypress: $component.keypressHandler }" class="form-control condition-value" />
         <button class="btn btn-danger btn-xs pull-right" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-minus-sign"></span> Remove</button>
     </div>
 </script>

--- a/public/app/ui/pages/search/SearchPage.js
+++ b/public/app/ui/pages/search/SearchPage.js
@@ -136,7 +136,7 @@
                     results([]);
                     this.displayResults(false);
                     this.query(undefined);
-                };
+                }.bind(this);
 
                 this.submit = function (callback) {
                     if (!this.canSubmit()) {
@@ -146,7 +146,7 @@
                     routes.pushState(this.searchUrlFor({ query: JSON.stringify(this.query()) }));
                     doSearch(callback);
                     return false;
-                };
+                }.bind(this);
 
                 this.searchUrlFor = function (overrides) {
                     var query;

--- a/public/app/ui/pages/search/search.html
+++ b/public/app/ui/pages/search/search.html
@@ -9,7 +9,7 @@
                         <div data-bind="component: { name: 'search/basic', params: { fields: inputFields, queryObservable: query } }"></div>
                         <!-- /ko -->
                         <!-- ko if: advancedMode -->
-                        <div data-bind="component: { name: 'search/query-builder', params: { fields: inputFields, maxDepth: 3, queryObservable: query } }"></div>
+                        <div data-bind="component: { name: 'search/query-builder', params: { fields: inputFields, maxDepth: 3, queryObservable: query, submit: submit } }"></div>
                         <!-- /ko -->
                         <!-- ko if: hasLimitedResults -->
                         <div class="alert alert-danger">

--- a/test/spec/ui/components/search/queryBuilder/QueryBuilderComponent.spec.js
+++ b/test/spec/ui/components/search/queryBuilder/QueryBuilderComponent.spec.js
@@ -41,6 +41,7 @@
                         });
                         it('Exposes view helper methods', function () {
                             expect(component.templateFor).to.be.a('function');
+                            expect(component.keypressHandler).to.be.a('function');
                         });
                         it('Sets a Group with a single empty Condition as the root node', function () {
                             expect(component.root() instanceof Group).to.equal(true);
@@ -94,6 +95,7 @@
                         });
                         it('Exposes view helper methods', function () {
                             expect(component.templateFor).to.be.a('function');
+                            expect(component.keypressHandler).to.be.a('function');
                         });
                         it('Sets a the correct query structure', function () {
                             expect(component.root() instanceof Group).to.equal(true);

--- a/test/spec/ui/components/search/queryBuilder/QueryBuilderComponent.spec.js
+++ b/test/spec/ui/components/search/queryBuilder/QueryBuilderComponent.spec.js
@@ -3,14 +3,14 @@
 
     define(
         [
+            'lodash',
             'chai',
-            'sinon',
             'knockout',
             'ui/components/search/queryBuilder/QueryBuilderComponent',
             'models/query/Group',
             'models/query/Condition'
         ],
-        function (chai, sinon, ko, QueryBuilderComponent, Group, Condition) {
+        function (_, chai, ko, QueryBuilderComponent, Group, Condition) {
             var expect = chai.expect;
 
             describe('The `QueryBuilderComponent` module', function () {
@@ -25,6 +25,7 @@
                             require([ 'fixtures/collections/searchInputFields' ], function (searchInputFields) {
                                 component = new QueryBuilderComponent({
                                     queryObservable: query,
+                                    submit: _.noop,
                                     fields: ko.observable(searchInputFields),
                                     maxDepth: 3
                                 });
@@ -59,7 +60,7 @@
                         });
                     });
                     describe('When constructed with an initial query', function () {
-                        var query, component;
+                        var query, submit, component;
                         beforeEach(function (done) {
                             query = ko.observable({
                                 operator: 'AND',
@@ -79,6 +80,7 @@
                             require([ 'fixtures/collections/searchInputFields' ], function (searchInputFields) {
                                 component = new QueryBuilderComponent({
                                     queryObservable: query,
+                                    submit: _.noop,
                                     fields: ko.observable(searchInputFields),
                                     maxDepth: 3
                                 });
@@ -123,6 +125,7 @@
                         expect(function () {
                             component = new QueryBuilderComponent({
                                 // The actual fields are unimportant here, but we need something so an empty object will do.
+                                submit: _.noop,
                                 fields: ko.observableArray([ {} ]),
                                 maxDepth: 3
                             });
@@ -136,10 +139,36 @@
                             component = new QueryBuilderComponent({
                                 // The actual fields are unimportant here, but we need something so an empty object will do.
                                 fields: ko.observableArray([ {} ]),
+                                submit: _.noop,
                                 queryObservable: 'foo',
                                 maxDepth: 3
                             });
                         }).to.throw('QueryBuilderComponent missing or invalid required parameter: `queryObservable`.');
+                    });
+                });
+                describe('With missing `submit` parameter', function () {
+                    var component;
+                    it('Throws an error', function () {
+                        expect(function () {
+                            component = new QueryBuilderComponent({
+                                fields: ko.observableArray([ {} ]),
+                                queryObservable: ko.observable(),
+                                maxDepth: 3
+                            });
+                        }).to.throw('QueryBuilderComponent missing or invalid required parameter: `submit`.');
+                    });
+                });
+                describe('With non-function `submit` parameter', function () {
+                    var component;
+                    it('Throws an error', function () {
+                        expect(function () {
+                            component = new QueryBuilderComponent({
+                                fields: ko.observableArray([ {} ]),
+                                submit: 'not a function',
+                                queryObservable: ko.observable(),
+                                maxDepth: 3
+                            });
+                        }).to.throw('QueryBuilderComponent missing or invalid required parameter: `submit`.');
                     });
                 });
                 describe('With missing `fields` parameter', function () {
@@ -147,6 +176,7 @@
                     it('Throws an error', function () {
                         expect(function () {
                             component = new QueryBuilderComponent({
+                                submit: _.noop,
                                 queryObservable: ko.observable(),
                                 maxDepth: 3
                             });
@@ -159,6 +189,7 @@
                         expect(function () {
                             component = new QueryBuilderComponent({
                                 // The actual fields are unimportant here, but we need something so an empty object will do.
+                                submit: _.noop,
                                 fields: ko.observableArray([ {} ]),
                                 queryObservable: ko.observable()
                             });


### PR DESCRIPTION
+ Add `keypress` handler that calls `submit` and returns `false` if the enter key is pressed, otherwise does not affect other keypresses.
+ Add missing `.bind()` calls to `SearchPage` view model.
+ Pass `submit` function from binding in `search.html` view .