### PR TITLE
Fix issue with whitespace in search.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rwahs-research-frontend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "SPA frontend for CollectiveAccess SimpleAPI",
   "main": "public/app/main.js",
   "scripts": {

--- a/public/app/models/query/Condition.js
+++ b/public/app/models/query/Condition.js
@@ -59,12 +59,9 @@
                     if (!query.comparator) {
                         throw new Error('Cannot parse Condition query, missing `comparator`');
                     }
-                    if (!query.value) {
-                        throw new Error('Cannot parse Condition query, missing `value`');
-                    }
                     this.selectedField(query.field);
                     this.selectedComparator(query.comparator);
-                    this.value(query.value);
+                    this.value(query.value || '');
                 };
             };
         }

--- a/public/app/models/query/Group.js
+++ b/public/app/models/query/Group.js
@@ -58,7 +58,7 @@
                         var childNode;
                         if (child.operator && child.children) {
                             childNode = new Group(queryBuilder, this);
-                        } else if (child.field && child.comparator && child.value) {
+                        } else if (child.field && child.comparator) {
                             childNode = new Condition(queryBuilder);
                         } else {
                             throw new Error('Cannot parse Group query, invalid data encountered in query structure: ' + JSON.stringify(child));

--- a/public/app/services/searchService.js
+++ b/public/app/services/searchService.js
@@ -18,6 +18,9 @@
 
             queryString = function (parameters) {
                 return _(parameters.children)
+                    .filter(function (child) {
+                        return child.hasOwnProperty('children') || child.value;
+                    })
                     .map(function (child) {
                         return child.hasOwnProperty('children') ?
                             '(' + queryString(child) + ')' :

--- a/public/app/util/convertBasicSearch.js
+++ b/public/app/util/convertBasicSearch.js
@@ -7,7 +7,6 @@
         ],
         function (_) {
             return function (field, text) {
-                text = text.trim();
                 return text.length === 0 ? undefined : {
                     operator: 'AND',
                     children: _.map(

--- a/test/spec/services/searchService.spec.js
+++ b/test/spec/services/searchService.spec.js
@@ -259,6 +259,50 @@
                                     });
                                 });
                             });
+                            describe('When invoked with multiple parameters including a parameter with no value', function () {
+                                describe('With the "AND" operator', function () {
+                                    var parameters, serviceError, serviceResult;
+                                    beforeEach(function (done) {
+                                        // This can happen, e.g. with a trailing whitespace in the original search text.
+                                        parameters = {
+                                            operator: 'AND',
+                                            children: [
+                                                {
+                                                    field: 'field',
+                                                    comparator: 'contains',
+                                                    value: 'value'
+                                                },
+                                                {
+                                                    field: 'another',
+                                                    comparator: 'notContains',
+                                                    value: 'search this'
+                                                },
+                                                {
+                                                    field: 'field',
+                                                    comparator: 'contains',
+                                                    value: ''
+                                                }
+                                            ]
+                                        };
+                                        service(parameters, function (err, result) {
+                                            serviceError = err;
+                                            serviceResult = result;
+                                            done();
+                                        });
+                                    });
+                                    it('Makes an AJAX call', function () {
+                                        sinon.assert.calledOnce($.ajax);
+                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value") AND !(another:"search this")');
+                                        expect($.ajax.args[0][0].success).to.be.a('function');
+                                        expect($.ajax.args[0][0].error).to.be.a('function');
+                                    });
+                                    it('Records a valid result', function () {
+                                        expect(serviceError).to.equal(undefined);
+                                        expect(serviceResult).to.be.an('array');
+                                        expect(serviceResult).to.have.length(3);
+                                    });
+                                });
+                            });
                         });
                     });
                     describe('When invoked with valid parameters including `ajaxOptions` option', function () {

--- a/test/spec/util/convertBasicSearch.spec.js
+++ b/test/spec/util/convertBasicSearch.spec.js
@@ -19,8 +19,25 @@
                     });
                 });
                 describe('When invoked with a string consisting of only whitespace', function () {
-                    it('Returns undefined', function () {
-                        expect(convertBasicSearch('field', '   ')).to.equal(undefined);
+                    it('Returns the correct query', function () {
+                        // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
+                        // text is `split` on any sequence of whitespace, which here gives an empty string from the
+                        // start of the search text and another empty string from the end of the search text.
+                        expect(convertBasicSearch('field', '   ')).to.deep.equal({
+                            operator: 'AND',
+                            children: [
+                                {
+                                    field: 'field',
+                                    comparator: 'contains',
+                                    value: ''
+                                },
+                                {
+                                    field: 'field',
+                                    comparator: 'contains',
+                                    value: ''
+                                }
+                            ]
+                        });
                     });
                 });
                 describe('When invoked with a single word', function () {
@@ -39,13 +56,26 @@
                 });
                 describe('When invoked with a single word with extraneous whitespace', function () {
                     it('Returns the correct query', function () {
+                        // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
+                        // text is `split` on any sequence of whitespace, which here gives an empty string from the
+                        // start of the search text and another empty string from the end of the search text.
                         expect(convertBasicSearch('field', '  foo  ')).to.deep.equal({
                             operator: 'AND',
                             children: [
                                 {
                                     field: 'field',
                                     comparator: 'contains',
+                                    value: ''
+                                },
+                                {
+                                    field: 'field',
+                                    comparator: 'contains',
                                     value: 'foo'
+                                },
+                                {
+                                    field: 'field',
+                                    comparator: 'contains',
+                                    value: ''
                                 }
                             ]
                         });
@@ -76,20 +106,36 @@
                     });
                 });
                 describe('When invoked with a multi-word string with extraneous whitespace', function () {
-                    expect(convertBasicSearch('field', '  forty    two ')).to.deep.equal({
-                        operator: 'AND',
-                        children: [
-                            {
-                                field: 'field',
-                                comparator: 'contains',
-                                value: 'forty'
-                            },
-                            {
-                                field: 'field',
-                                comparator: 'contains',
-                                value: 'two'
-                            }
-                        ]
+                    it('Returns the correct query', function () {
+                        // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
+                        // text is `split` on any sequence of whitespace, which here gives an empty string from the
+                        // start of the search text and another empty string from the end of the search text.  Internal
+                        // sequences of whitespace are collapsed normally.
+                        expect(convertBasicSearch('field', '  forty    two ')).to.deep.equal({
+                            operator: 'AND',
+                            children: [
+                                {
+                                    field: 'field',
+                                    comparator: 'contains',
+                                    value: ''
+                                },
+                                {
+                                    field: 'field',
+                                    comparator: 'contains',
+                                    value: 'forty'
+                                },
+                                {
+                                    field: 'field',
+                                    comparator: 'contains',
+                                    value: 'two'
+                                },
+                                {
+                                    field: 'field',
+                                    comparator: 'contains',
+                                    value: ''
+                                }
+                            ]
+                        });
                     });
                 });
             });


### PR DESCRIPTION
+ There is a `subscribe` loop between the `searchText` observable
  and the passed-in `queryObservable`, in the `BasicSearchComponent`.
  This allows the search form to function consistently between basic
  and advanced search.
+ A recent change introduced a `trim()` call in `convertBasicSearch`,
  which is used by one of these `subscribe`s to convert the `searchText`
  value into the object structure stored in the `queryObservable`.
+ This `trim()` call was preventing the user from typing a space character,
  because it was removed from the query structure, and then removed
  from the `searchText` on the return journey.
+ This change removes the `trim()` call, and allows the `Condition` model
  to have a falsy value (e.g. empty string), which means that instead of being
  removed, the whitespace just creates an empty condition in the advanced
  search form.
+ The `searchService` now also filters out any empty-`value`d conditions
  while constructing the CA search query syntax string.