### PR TITLE
Support for `empty` and `notEmpty` operators.

### DIFF
--- a/public/app/config/comparators.js
+++ b/public/app/config/comparators.js
@@ -1,0 +1,38 @@
+(function () {
+    'use strict';
+
+    define(function () {
+        return [
+            {
+                key: 'contains',
+                labelText: 'contains',
+                valueType: 'text'
+            },
+            {
+                key: 'notContains',
+                labelText: 'does not contain',
+                valueType: 'text'
+            },
+            {
+                key: 'startsWith',
+                labelText: 'starts with',
+                valueType: 'text'
+            },
+            {
+                key: 'notStartsWith',
+                labelText: 'does not start with',
+                valueType: 'text'
+            },
+            {
+                key: 'empty',
+                labelText: 'is empty',
+                valueType: false
+            },
+            {
+                key: 'notEmpty',
+                labelText: 'is not empty',
+                valueType: false
+            }
+        ];
+    });
+}());

--- a/public/app/config/settings.js
+++ b/public/app/config/settings.js
@@ -9,12 +9,14 @@
             return function () {
                 container.register('settings.all', {
                     collectionName: 'All Collections',
+                    comparators: 'config/comparators',
                     searchInputFields: 'config/collections/all/searchInputFields',
                     searchResultFields: 'config/collections/all/searchResultFields'
                 });
                 container.register('settings.library', {
                     collectionName: 'Library',
                     labelField: 'Title',
+                    comparators: 'config/comparators',
                     searchInputFields: 'config/collections/library/searchInputFields',
                     searchResultFields: 'config/collections/library/searchResultFields',
                     detailFields: 'config/collections/library/detailFields'
@@ -22,6 +24,7 @@
                 container.register('settings.photographs', {
                     collectionName: 'Photographs',
                     labelField: 'Title',
+                    comparators: 'config/comparators',
                     searchInputFields: 'config/collections/photographs/searchInputFields',
                     searchResultFields: 'config/collections/photographs/searchResultFields',
                     detailFields: 'config/collections/photographs/detailFields'
@@ -29,6 +32,7 @@
                 container.register('settings.museum', {
                     collectionName: 'Museum',
                     labelField: 'ItemName',
+                    comparators: 'config/comparators',
                     searchInputFields: 'config/collections/museum/searchInputFields',
                     searchResultFields: 'config/collections/museum/searchResultFields',
                     detailFields: 'config/collections/museum/detailFields'
@@ -36,6 +40,7 @@
                 container.register('settings.memorials', {
                     collectionName: 'Public Memorials',
                     labelField: 'ItemName',
+                    comparators: 'config/comparators',
                     searchInputFields: 'config/collections/memorials/searchInputFields',
                     searchResultFields: 'config/collections/memorials/searchResultFields',
                     detailFields: 'config/collections/memorials/detailFields'

--- a/public/app/models/query/Condition.js
+++ b/public/app/models/query/Condition.js
@@ -21,35 +21,59 @@
                     return [
                         {
                             key: 'contains',
-                            labelText: 'contains'
+                            labelText: 'contains',
+                            valueType: 'text'
                         },
                         {
                             key: 'notContains',
-                            labelText: 'does not contain'
+                            labelText: 'does not contain',
+                            valueType: 'text'
                         },
                         {
                             key: 'startsWith',
-                            labelText: 'starts with'
+                            labelText: 'starts with',
+                            valueType: 'text'
                         },
                         {
                             key: 'notStartsWith',
-                            labelText: 'does not start with'
+                            labelText: 'does not start with',
+                            valueType: 'text'
+                        },
+                        {
+                            key: 'empty',
+                            labelText: 'is empty',
+                            valueType: false
+                        },
+                        {
+                            key: 'notEmpty',
+                            labelText: 'is not empty',
+                            valueType: false
                         }
                     ];
                 });
 
+                this.valueType = ko.pureComputed(function () {
+                    var comparator = _(this.comparators()).find({ key: this.selectedComparator() });
+                    return comparator ? comparator.valueType : false;
+                }.bind(this));
+
+                this.valueTypeIs = function (type) {
+                    return this.valueType() === type;
+                }.bind(this);
+
                 this.query = ko.pureComputed(function () {
-                    var field, comparator, value;
-                    field = this.selectedField();
-                    comparator = this.selectedComparator();
-                    value = this.value();
-                    return (field && comparator && value) ?
-                        {
-                            field: field,
-                            comparator: comparator,
-                            value: value
-                        } :
-                        undefined;
+                    var result;
+                    result = {
+                        field: this.selectedField(),
+                        comparator: this.selectedComparator()
+                    };
+                    if (!result.field || !result.comparator) {
+                        return undefined;
+                    }
+                    if (this.valueType()) {
+                        result.value = this.value();
+                    }
+                    return result;
                 }.bind(this));
 
                 this.parse = function (query) {

--- a/public/app/models/query/Condition.js
+++ b/public/app/models/query/Condition.js
@@ -18,43 +18,12 @@
                 });
 
                 this.comparators = ko.pureComputed(function () {
-                    return [
-                        {
-                            key: 'contains',
-                            labelText: 'contains',
-                            valueType: 'text'
-                        },
-                        {
-                            key: 'notContains',
-                            labelText: 'does not contain',
-                            valueType: 'text'
-                        },
-                        {
-                            key: 'startsWith',
-                            labelText: 'starts with',
-                            valueType: 'text'
-                        },
-                        {
-                            key: 'notStartsWith',
-                            labelText: 'does not start with',
-                            valueType: 'text'
-                        },
-                        {
-                            key: 'empty',
-                            labelText: 'is empty',
-                            valueType: false
-                        },
-                        {
-                            key: 'notEmpty',
-                            labelText: 'is not empty',
-                            valueType: false
-                        }
-                    ];
+                    return queryBuilder.comparators();
                 });
 
                 this.valueType = ko.pureComputed(function () {
                     var comparator = _(this.comparators()).find({ key: this.selectedComparator() });
-                    return comparator ? comparator.valueType : false;
+                    return comparator ? comparator.valueType : undefined;
                 }.bind(this));
 
                 this.valueTypeIs = function (type) {
@@ -85,7 +54,7 @@
                     }
                     this.selectedField(query.field);
                     this.selectedComparator(query.comparator);
-                    this.value(query.value || '');
+                    this.value(this.valueType() ? (query.value || '') : undefined);
                 };
             };
         }

--- a/public/app/services/searchService.js
+++ b/public/app/services/searchService.js
@@ -7,24 +7,23 @@
             'jquery'
         ],
         function (_, $) {
-            var comparatorFormatters, queryString;
+            var comparatorTemplates, queryString;
 
-            comparatorFormatters = {
+            comparatorTemplates = {
                 contains: _.template('(<%= field %>:"<%= value %>")'),
                 notContains: _.template('!(<%= field %>:"<%= value %>")'),
                 startsWith: _.template('(<%= field %>:"<%= value %>"*)'),
-                notStartsWith: _.template('!(<%= field %>:"<%= value %>"*)')
+                notStartsWith: _.template('!(<%= field %>:"<%= value %>"*)'),
+                empty: _.template('<%= field %>:[BLANK]'),
+                notEmpty: _.template('<%= field %>:*')
             };
 
             queryString = function (parameters) {
                 return _(parameters.children)
-                    .filter(function (child) {
-                        return child.hasOwnProperty('children') || child.value;
-                    })
                     .map(function (child) {
                         return child.hasOwnProperty('children') ?
                             '(' + queryString(child) + ')' :
-                            comparatorFormatters[child.comparator](child);
+                            comparatorTemplates[child.comparator](child);
                     })
                     .join(' ' + parameters.operator + ' ');
             };

--- a/public/app/services/searchService.js
+++ b/public/app/services/searchService.js
@@ -14,8 +14,8 @@
                 notContains: _.template('!(<%= field %>:"<%= value %>")'),
                 startsWith: _.template('(<%= field %>:"<%= value %>"*)'),
                 notStartsWith: _.template('!(<%= field %>:"<%= value %>"*)'),
-                empty: _.template('<%= field %>:[BLANK]'),
-                notEmpty: _.template('<%= field %>:*')
+                empty: _.template('(<%= field %>:[BLANK])'),
+                notEmpty: _.template('(<%= field %>:*)')
             };
 
             queryString = function (parameters) {

--- a/public/app/ui/components/search/queryBuilder/query-builder.html
+++ b/public/app/ui/components/search/queryBuilder/query-builder.html
@@ -6,7 +6,9 @@
     <div class="condition">
         <select data-bind="options: fields, optionsCaption: '', optionsText: 'labelText', optionsValue: 'key', value: selectedField" class="form-control field styled-select"></select>
         <select data-bind="options: comparators, optionsCaption: '', optionsText: 'labelText', optionsValue: 'key', value: selectedComparator" class="form-control comparator styled-select"></select>
+        <!-- ko if: valueTypeIs('text') -->
         <input type="text" data-bind="textInput: value, event: { keypress: $component.keypressHandler }" class="form-control condition-value" />
+        <!-- /ko -->
         <button class="btn btn-danger btn-xs pull-right" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-minus-sign"></span> Remove</button>
     </div>
 </script>

--- a/public/app/ui/pages/search/search.html
+++ b/public/app/ui/pages/search/search.html
@@ -63,10 +63,12 @@
         <code data-bind="text: submittedQueryText"></code>.
     </p>
     <!-- /ko -->
-    <!-- ko if: shopBaseUrl -->
+    <!-- ko if: displayShopLink -->
     <p>
-        The <a href="#" target="_blank" data-bind="attr: { href: shopBaseUrl }">shop</a> may have results related to
-        <a href="#" target="_blank" data-bind="text: shopSearchText, attr: { href: shopSearchUrl }">your query</a>.
+        <a href="#" target="_blank" data-bind="attr: { href: shopSearchUrl }">
+            The shop may have results related to
+            <span data-bind="text: shopSearchText">your query</span>
+        </a>.
     </p>
     <!-- /ko -->
     <!-- ko if: hasResults -->

--- a/public/app/ui/pages/search/search.html
+++ b/public/app/ui/pages/search/search.html
@@ -9,7 +9,7 @@
                         <div data-bind="component: { name: 'search/basic', params: { fields: inputFields, queryObservable: query } }"></div>
                         <!-- /ko -->
                         <!-- ko if: advancedMode -->
-                        <div data-bind="component: { name: 'search/query-builder', params: { fields: inputFields, maxDepth: 3, queryObservable: query, submit: submit } }"></div>
+                        <div data-bind="component: { name: 'search/query-builder', params: { fields: inputFields, comparators: comparators, maxDepth: 3, queryObservable: query, submit: submit } }"></div>
                         <!-- /ko -->
                         <!-- ko if: queryModified -->
                         <p>Modified query: <code data-bind="text: queryText"></code>.</p>

--- a/public/app/util/convertBasicSearch.js
+++ b/public/app/util/convertBasicSearch.js
@@ -7,7 +7,6 @@
         ],
         function (_) {
             return function (field, text, operator) {
-                console.log('convertBasicSearch with operator = ' + operator);
                 return text.length === 0 ? undefined : {
                     operator: operator || 'AND',
                     children: _.map(

--- a/test/fixtures/comparators.js
+++ b/test/fixtures/comparators.js
@@ -1,0 +1,38 @@
+(function () {
+    'use strict';
+
+    define(function () {
+        return [
+            {
+                key: 'contains',
+                labelText: 'contains',
+                valueType: 'text'
+            },
+            {
+                key: 'notContains',
+                labelText: 'does not contain',
+                valueType: 'text'
+            },
+            {
+                key: 'startsWith',
+                labelText: 'starts with',
+                valueType: 'text'
+            },
+            {
+                key: 'notStartsWith',
+                labelText: 'does not start with',
+                valueType: 'text'
+            },
+            {
+                key: 'empty',
+                labelText: 'is empty',
+                valueType: false
+            },
+            {
+                key: 'notEmpty',
+                labelText: 'is not empty',
+                valueType: false
+            }
+        ];
+    });
+}());

--- a/test/spec/config/settings.spec.js
+++ b/test/spec/config/settings.spec.js
@@ -28,12 +28,14 @@
                     it('Registers the correct settings', function () {
                         expect(container.resolve('settings.all')).to.deep.equal({
                             collectionName: 'All Collections',
+                            comparators: 'config/comparators',
                             searchInputFields: 'config/collections/all/searchInputFields',
                             searchResultFields: 'config/collections/all/searchResultFields'
                         });
                         expect(container.resolve('settings.library')).to.deep.equal({
                             collectionName: 'Library',
                             labelField: 'Title',
+                            comparators: 'config/comparators',
                             searchInputFields: 'config/collections/library/searchInputFields',
                             searchResultFields: 'config/collections/library/searchResultFields',
                             detailFields: 'config/collections/library/detailFields'
@@ -41,6 +43,7 @@
                         expect(container.resolve('settings.memorials')).to.deep.equal({
                             collectionName: 'Public Memorials',
                             labelField: 'ItemName',
+                            comparators: 'config/comparators',
                             searchInputFields: 'config/collections/memorials/searchInputFields',
                             searchResultFields: 'config/collections/memorials/searchResultFields',
                             detailFields: 'config/collections/memorials/detailFields'
@@ -48,6 +51,7 @@
                         expect(container.resolve('settings.museum')).to.deep.equal({
                             collectionName: 'Museum',
                             labelField: 'ItemName',
+                            comparators: 'config/comparators',
                             searchInputFields: 'config/collections/museum/searchInputFields',
                             searchResultFields: 'config/collections/museum/searchResultFields',
                             detailFields: 'config/collections/museum/detailFields'
@@ -55,6 +59,7 @@
                         expect(container.resolve('settings.photographs')).to.deep.equal({
                             collectionName: 'Photographs',
                             labelField: 'Title',
+                            comparators: 'config/comparators',
                             searchInputFields: 'config/collections/photographs/searchInputFields',
                             searchResultFields: 'config/collections/photographs/searchResultFields',
                             detailFields: 'config/collections/photographs/detailFields'

--- a/test/spec/models/query/Condition.spec.js
+++ b/test/spec/models/query/Condition.spec.js
@@ -31,9 +31,11 @@
                         expect(ko.isObservable(condition.fields)).to.equal(true);
                         expect(ko.isObservable(condition.comparators)).to.equal(true);
                         expect(ko.isObservable(condition.query)).to.equal(true);
+                        expect(ko.isObservable(condition.valueType)).to.equal(true);
                     });
                     it('Exposes helper methods', function () {
                         expect(condition.parse).to.be.a('function');
+                        expect(condition.valueTypeIs).to.be.a('function');
                     });
                     it('Exposes the correct default values', function () {
                         expect(condition.selectedField()).to.equal(undefined);

--- a/test/spec/models/query/Condition.spec.js
+++ b/test/spec/models/query/Condition.spec.js
@@ -16,11 +16,15 @@
                 });
                 describe('When constructed', function () {
                     var queryBuilder, condition;
-                    beforeEach(function () {
-                        queryBuilder = {
-                            maxDepth: ko.observable(3)
-                        };
-                        condition = new Condition(queryBuilder);
+                    beforeEach(function (done) {
+                        require([ 'fixtures/comparators' ], function (comparators) {
+                            queryBuilder = {
+                                maxDepth: ko.observable(3),
+                                comparators: ko.observable(comparators)
+                            };
+                            condition = new Condition(queryBuilder);
+                            done();
+                        });
                     });
                     it('Exposes observables', function () {
                         expect(ko.isObservable(condition.selectedField)).to.equal(true);
@@ -43,17 +47,32 @@
                         expect(condition.value()).to.equal('');
                     });
                     describe('The `parse` method', function () {
-                        beforeEach(function () {
-                            condition.parse({
-                                field: 'field',
-                                comparator: 'comparator',
-                                value: 'value'
+                        describe('With a field of value type "text"', function () {
+                            beforeEach(function () {
+                                condition.parse({
+                                    field: 'field',
+                                    comparator: 'contains',
+                                    value: 'value'
+                                });
+                            });
+                            it('Sets the correct values', function () {
+                                expect(condition.selectedField()).to.equal('field');
+                                expect(condition.selectedComparator()).to.equal('contains');
+                                expect(condition.value()).to.equal('value');
                             });
                         });
-                        it('Sets the correct values', function () {
-                            expect(condition.selectedField()).to.equal('field');
-                            expect(condition.selectedComparator()).to.equal('comparator');
-                            expect(condition.value()).to.equal('value');
+                        describe('With a field with no value', function () {
+                            beforeEach(function () {
+                                condition.parse({
+                                    field: 'field',
+                                    comparator: 'empty'
+                                });
+                            });
+                            it('Sets the correct values', function () {
+                                expect(condition.selectedField()).to.equal('field');
+                                expect(condition.selectedComparator()).to.equal('empty');
+                                expect(condition.value()).to.equal(undefined);
+                            });
                         });
                     });
                 });

--- a/test/spec/services/searchService.spec.js
+++ b/test/spec/services/searchService.spec.js
@@ -292,7 +292,44 @@
                                     });
                                     it('Makes an AJAX call', function () {
                                         sinon.assert.calledOnce($.ajax);
-                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value") AND !(another:"search this")');
+                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:"value") AND !(another:"search this") AND (field:"")');
+                                        expect($.ajax.args[0][0].success).to.be.a('function');
+                                        expect($.ajax.args[0][0].error).to.be.a('function');
+                                    });
+                                    it('Records a valid result', function () {
+                                        expect(serviceError).to.equal(undefined);
+                                        expect(serviceResult).to.be.an('array');
+                                        expect(serviceResult).to.have.length(3);
+                                    });
+                                });
+                            });
+                            describe('When invoked with multiple parameters including parameters which don\'t accept a value', function () {
+                                describe('With the "AND" operator', function () {
+                                    var parameters, serviceError, serviceResult;
+                                    beforeEach(function (done) {
+                                        // This can happen, e.g. with a trailing whitespace in the original search text.
+                                        parameters = {
+                                            operator: 'AND',
+                                            children: [
+                                                {
+                                                    field: 'field',
+                                                    comparator: 'empty'
+                                                },
+                                                {
+                                                    field: 'another',
+                                                    comparator: 'notEmpty'
+                                                }
+                                            ]
+                                        };
+                                        service(parameters, function (err, result) {
+                                            serviceError = err;
+                                            serviceResult = result;
+                                            done();
+                                        });
+                                    });
+                                    it('Makes an AJAX call', function () {
+                                        sinon.assert.calledOnce($.ajax);
+                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=field:[BLANK] AND another:*');
                                         expect($.ajax.args[0][0].success).to.be.a('function');
                                         expect($.ajax.args[0][0].error).to.be.a('function');
                                     });

--- a/test/spec/services/searchService.spec.js
+++ b/test/spec/services/searchService.spec.js
@@ -329,7 +329,7 @@
                                     });
                                     it('Makes an AJAX call', function () {
                                         sinon.assert.calledOnce($.ajax);
-                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=field:[BLANK] AND another:*');
+                                        expect($.ajax.args[0][0].url).to.equal('http://server.name/path/to/api?q=(field:[BLANK]) AND (another:*)');
                                         expect($.ajax.args[0][0].success).to.be.a('function');
                                         expect($.ajax.args[0][0].error).to.be.a('function');
                                     });

--- a/test/spec/ui/components/search/basic/BasicSearchComponent.spec.js
+++ b/test/spec/ui/components/search/basic/BasicSearchComponent.spec.js
@@ -177,6 +177,9 @@
                                     });
                                 });
                             });
+                            afterEach(function () {
+                                component.dispose();
+                            });
                         });
                         describe('When constructed with an initial query that can be converted to a basic search', function () {
                             var query, component;
@@ -242,6 +245,9 @@
                             it('Does not display the warning about losing query details', function () {
                                 expect(component.displayLostQueryWarning()).to.equal(false);
                             });
+                            afterEach(function () {
+                                component.dispose();
+                            });
                         });
                         describe('When constructed with an initial query that cannot be converted to a basic search', function () {
                             var query, component;
@@ -306,6 +312,9 @@
                             });
                             it('Displays the warning about losing query details', function () {
                                 expect(component.displayLostQueryWarning()).to.equal(true);
+                            });
+                            afterEach(function () {
+                                component.dispose();
                             });
                         });
                     });
@@ -427,6 +436,9 @@
                                         });
                                     });
                                 });
+                            });
+                            afterEach(function () {
+                                component.dispose();
                             });
                         });
                     });

--- a/test/spec/ui/components/search/queryBuilder/QueryBuilderComponent.spec.js
+++ b/test/spec/ui/components/search/queryBuilder/QueryBuilderComponent.spec.js
@@ -22,15 +22,22 @@
                         var query, component;
                         beforeEach(function (done) {
                             query = ko.observable();
-                            require([ 'fixtures/collections/searchInputFields' ], function (searchInputFields) {
-                                component = new QueryBuilderComponent({
-                                    queryObservable: query,
-                                    submit: _.noop,
-                                    fields: ko.observable(searchInputFields),
-                                    maxDepth: 3
-                                });
-                                done();
-                            });
+                            require(
+                                [
+                                    'fixtures/comparators',
+                                    'fixtures/collections/searchInputFields'
+                                ],
+                                function (comparators, searchInputFields) {
+                                    component = new QueryBuilderComponent({
+                                        queryObservable: query,
+                                        submit: _.noop,
+                                        fields: ko.observable(searchInputFields),
+                                        comparators: ko.observable(comparators),
+                                        maxDepth: 3
+                                    });
+                                    done();
+                                }
+                            );
                         });
                         it('Returns an object', function () {
                             expect(component).to.be.an('object');
@@ -60,7 +67,7 @@
                         });
                     });
                     describe('When constructed with an initial query', function () {
-                        var query, submit, component;
+                        var query, component;
                         beforeEach(function (done) {
                             query = ko.observable({
                                 operator: 'AND',
@@ -72,20 +79,27 @@
                                     },
                                     {
                                         field: 'second',
-                                        comparator: '!contains',
+                                        comparator: 'notContains',
                                         value: 'bar'
                                     }
                                 ]
                             });
-                            require([ 'fixtures/collections/searchInputFields' ], function (searchInputFields) {
-                                component = new QueryBuilderComponent({
-                                    queryObservable: query,
-                                    submit: _.noop,
-                                    fields: ko.observable(searchInputFields),
-                                    maxDepth: 3
-                                });
-                                done();
-                            });
+                            require(
+                                [
+                                    'fixtures/comparators',
+                                    'fixtures/collections/searchInputFields'
+                                ],
+                                function (comparators, searchInputFields) {
+                                    component = new QueryBuilderComponent({
+                                        queryObservable: query,
+                                        submit: _.noop,
+                                        fields: ko.observable(searchInputFields),
+                                        comparators: ko.observable(comparators),
+                                        maxDepth: 3
+                                    });
+                                    done();
+                                }
+                            );
                         });
                         it('Returns an object', function () {
                             expect(component).to.be.an('object');
@@ -99,7 +113,7 @@
                             expect(component.templateFor).to.be.a('function');
                             expect(component.keypressHandler).to.be.a('function');
                         });
-                        it('Sets a the correct query structure', function () {
+                        it('Sets the correct query structure', function () {
                             expect(component.root() instanceof Group).to.equal(true);
                             expect(component.root().children()).to.have.length(2);
                             expect(component.root().children()[0] instanceof Condition).to.equal(true);
@@ -108,7 +122,7 @@
                             expect(component.root().children()[0].value()).to.equal('foo');
                             expect(component.root().children()[1] instanceof Condition).to.equal(true);
                             expect(component.root().children()[1].selectedField()).to.equal('second');
-                            expect(component.root().children()[1].selectedComparator()).to.equal('!contains');
+                            expect(component.root().children()[1].selectedComparator()).to.equal('notContains');
                             expect(component.root().children()[1].value()).to.equal('bar');
                         });
                         it('Sets the input fields', function () {
@@ -127,6 +141,7 @@
                                 // The actual fields are unimportant here, but we need something so an empty object will do.
                                 submit: _.noop,
                                 fields: ko.observableArray([ {} ]),
+                                comparators: ko.observableArray([ {} ]),
                                 maxDepth: 3
                             });
                         }).to.throw('QueryBuilderComponent missing or invalid required parameter: `queryObservable`.');
@@ -139,6 +154,7 @@
                             component = new QueryBuilderComponent({
                                 // The actual fields are unimportant here, but we need something so an empty object will do.
                                 fields: ko.observableArray([ {} ]),
+                                comparators: ko.observableArray([ {} ]),
                                 submit: _.noop,
                                 queryObservable: 'foo',
                                 maxDepth: 3
@@ -151,7 +167,9 @@
                     it('Throws an error', function () {
                         expect(function () {
                             component = new QueryBuilderComponent({
+                                // The actual fields are unimportant here, but we need something so an empty object will do.
                                 fields: ko.observableArray([ {} ]),
+                                comparators: ko.observableArray([ {} ]),
                                 queryObservable: ko.observable(),
                                 maxDepth: 3
                             });
@@ -163,7 +181,9 @@
                     it('Throws an error', function () {
                         expect(function () {
                             component = new QueryBuilderComponent({
+                                // The actual fields are unimportant here, but we need something so an empty object will do.
                                 fields: ko.observableArray([ {} ]),
+                                comparators: ko.observableArray([ {} ]),
                                 submit: 'not a function',
                                 queryObservable: ko.observable(),
                                 maxDepth: 3
@@ -176,11 +196,26 @@
                     it('Throws an error', function () {
                         expect(function () {
                             component = new QueryBuilderComponent({
+                                comparators: ko.observableArray([ {} ]),
                                 submit: _.noop,
                                 queryObservable: ko.observable(),
                                 maxDepth: 3
                             });
                         }).to.throw('QueryBuilderComponent missing required parameter: `fields`.');
+                    });
+                });
+                describe('With missing `comparators` parameter', function () {
+                    var component;
+                    it('Throws an error', function () {
+                        expect(function () {
+                            component = new QueryBuilderComponent({
+                                // The actual fields are unimportant here, but we need something so an empty object will do.
+                                submit: _.noop,
+                                fields: ko.observableArray([ {} ]),
+                                queryObservable: ko.observable(),
+                                maxDepth: 3
+                            });
+                        }).to.throw('QueryBuilderComponent missing required parameter: `comparators`.');
                     });
                 });
                 describe('With missing `maxDepth` parameter', function () {
@@ -190,6 +225,7 @@
                             component = new QueryBuilderComponent({
                                 // The actual fields are unimportant here, but we need something so an empty object will do.
                                 submit: _.noop,
+                                comparators: ko.observableArray([ {} ]),
                                 fields: ko.observableArray([ {} ]),
                                 queryObservable: ko.observable()
                             });

--- a/test/spec/ui/pages/search/SearchPage.spec.js
+++ b/test/spec/ui/pages/search/SearchPage.spec.js
@@ -32,6 +32,7 @@
                                 container.register('search.collection', searchService);
                                 container.register('settings.collection', {
                                     collectionName: 'Collection',
+                                    comparators: 'fixtures/comparators',
                                     searchInputFields: 'fixtures/collections/searchInputFields',
                                     searchResultFields: 'fixtures/collections/searchResultFields'
                                 });
@@ -79,6 +80,7 @@
                                     expect(ko.isPureComputed(page.shopBaseUrl)).to.equal(true);
                                     expect(ko.isPureComputed(page.shopSearchUrl)).to.equal(true);
                                     expect(ko.isPureComputed(page.shopSearchText)).to.equal(true);
+                                    expect(ko.isPureComputed(page.displayShopLink)).to.equal(true);
                                 });
                                 it('Exposes life cycle methods', function () {
                                     expect(page.attaching).to.be.a('function');
@@ -330,6 +332,7 @@
                                 container.register('search.collection', searchService);
                                 container.register('settings.collection', {
                                     collectionName: 'Collection',
+                                    comparators: 'fixtures/comparators',
                                     searchInputFields: 'fixtures/collections/singleSearchInputField',
                                     searchResultFields: 'fixtures/collections/searchResultFields'
                                 });
@@ -395,6 +398,7 @@
                             });
                             container.register('settings.collection', {
                                 collectionName: 'Collection',
+                                comparators: 'fixtures/comparators',
                                 searchInputFields: 'fixtures/collections/searchInputFields',
                                 searchResultFields: 'fixtures/collections/searchResultFields'
                             });
@@ -421,50 +425,55 @@
                             it('Returns an object', function () {
                                 expect(page).to.be.an('object');
                             });
-                            describe('When bound to the view', function () {
+                            describe('When attached', function () {
                                 var containerElement;
                                 beforeEach(function (done) {
                                     containerElement = document.createElement('div');
-                                    page.binding(containerElement, done);
+                                    page.attaching(containerElement, done);
                                 });
-                                describe('With non-empty query', function () {
-                                    var query;
-                                    beforeEach(function () {
-                                        query = {
-                                            operator: 'AND',
-                                            children: [
-                                                {
-                                                    field: 'second',
-                                                    comparator: 'contains',
-                                                    value: 'query'
-                                                }
-                                            ]
-                                        };
-                                        page.query(query);
+                                describe('When bound to the view', function () {
+                                    beforeEach(function (done) {
+                                        page.binding(containerElement, done);
                                     });
-                                    describe('When the search form is submitted', function () {
+                                    describe('With non-empty query', function () {
+                                        var query;
                                         beforeEach(function () {
-                                            page.submit();
+                                            query = {
+                                                operator: 'AND',
+                                                children: [
+                                                    {
+                                                        field: 'second',
+                                                        comparator: 'contains',
+                                                        value: 'query'
+                                                    }
+                                                ]
+                                            };
+                                            page.query(query);
                                         });
-                                        it('Calls the specified search service with the given query', function () {
-                                            sinon.assert.calledOnce(searchService);
-                                            sinon.assert.calledWith(searchService, query);
-                                        });
-                                        it('Has results that are not limited', function () {
-                                            expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
-                                            expect(page.hasResults()).to.equal(true);
-                                            expect(page.hasLimitedResults()).to.equal(false);
-                                        });
-                                        it('Is displaying results', function () {
-                                            expect(page.displayResults()).to.equal(true);
-                                        });
-                                        it('Has displayed and then hidden the loading animation', function () {
-                                            expect(overlay.loading.callCount).to.equal(2);
-                                            expect(overlay.loading.getCall(0).args).to.deep.equal([ true ]);
-                                            expect(overlay.loading.getCall(1).args).to.deep.equal([ false ]);
-                                        });
-                                        it('Has not displayed any errors', function () {
-                                            expect(overlay.error.callCount).to.equal(0);
+                                        describe('When the search form is submitted', function () {
+                                            beforeEach(function () {
+                                                page.submit();
+                                            });
+                                            it('Calls the specified search service with the given query', function () {
+                                                sinon.assert.calledOnce(searchService);
+                                                sinon.assert.calledWith(searchService, query);
+                                            });
+                                            it('Has results that are not limited', function () {
+                                                expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
+                                                expect(page.hasResults()).to.equal(true);
+                                                expect(page.hasLimitedResults()).to.equal(false);
+                                            });
+                                            it('Is displaying results', function () {
+                                                expect(page.displayResults()).to.equal(true);
+                                            });
+                                            it('Has displayed and then hidden the loading animation', function () {
+                                                expect(overlay.loading.callCount).to.equal(2);
+                                                expect(overlay.loading.getCall(0).args).to.deep.equal([ true ]);
+                                                expect(overlay.loading.getCall(1).args).to.deep.equal([ false ]);
+                                            });
+                                            it('Has not displayed any errors', function () {
+                                                expect(overlay.error.callCount).to.equal(0);
+                                            });
                                         });
                                     });
                                 });
@@ -491,6 +500,7 @@
                             });
                             container.register('settings.collection', {
                                 collectionName: 'Collection',
+                                comparators: 'fixtures/comparators',
                                 searchInputFields: 'fixtures/collections/searchInputFields',
                                 searchResultFields: 'fixtures/collections/searchResultFields'
                             });
@@ -517,50 +527,55 @@
                             it('Returns an object', function () {
                                 expect(page).to.be.an('object');
                             });
-                            describe('When bound to the view', function () {
+                            describe('When attached', function () {
                                 var containerElement;
                                 beforeEach(function (done) {
                                     containerElement = document.createElement('div');
-                                    page.binding(containerElement, done);
+                                    page.attaching(containerElement, done);
                                 });
-                                describe('With non-empty query', function () {
-                                    var query;
-                                    beforeEach(function () {
-                                        query = {
-                                            operator: 'AND',
-                                            children: [
-                                                {
-                                                    field: 'second',
-                                                    comparator: 'contains',
-                                                    value: 'query'
-                                                }
-                                            ]
-                                        };
-                                        page.query(query);
+                                describe('When bound to the view', function () {
+                                    beforeEach(function (done) {
+                                        page.binding(containerElement, done);
                                     });
-                                    describe('When the search form is submitted', function () {
+                                    describe('With non-empty query', function () {
+                                        var query;
                                         beforeEach(function () {
-                                            page.submit();
+                                            query = {
+                                                operator: 'AND',
+                                                children: [
+                                                    {
+                                                        field: 'second',
+                                                        comparator: 'contains',
+                                                        value: 'query'
+                                                    }
+                                                ]
+                                            };
+                                            page.query(query);
                                         });
-                                        it('Calls the specified search service with the given query', function () {
-                                            sinon.assert.calledOnce(searchService);
-                                            sinon.assert.calledWith(searchService, query);
-                                        });
-                                        it('Has results that have been limited', function () {
-                                            expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
-                                            expect(page.hasResults()).to.equal(true);
-                                            expect(page.hasLimitedResults()).to.equal(true);
-                                        });
-                                        it('Is displaying results', function () {
-                                            expect(page.displayResults()).to.equal(true);
-                                        });
-                                        it('Has displayed and then hidden the loading animation', function () {
-                                            expect(overlay.loading.callCount).to.equal(2);
-                                            expect(overlay.loading.getCall(0).args).to.deep.equal([ true ]);
-                                            expect(overlay.loading.getCall(1).args).to.deep.equal([ false ]);
-                                        });
-                                        it('Has not displayed any errors', function () {
-                                            expect(overlay.error.callCount).to.equal(0);
+                                        describe('When the search form is submitted', function () {
+                                            beforeEach(function () {
+                                                page.submit();
+                                            });
+                                            it('Calls the specified search service with the given query', function () {
+                                                sinon.assert.calledOnce(searchService);
+                                                sinon.assert.calledWith(searchService, query);
+                                            });
+                                            it('Has results that have been limited', function () {
+                                                expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
+                                                expect(page.hasResults()).to.equal(true);
+                                                expect(page.hasLimitedResults()).to.equal(true);
+                                            });
+                                            it('Is displaying results', function () {
+                                                expect(page.displayResults()).to.equal(true);
+                                            });
+                                            it('Has displayed and then hidden the loading animation', function () {
+                                                expect(overlay.loading.callCount).to.equal(2);
+                                                expect(overlay.loading.getCall(0).args).to.deep.equal([ true ]);
+                                                expect(overlay.loading.getCall(1).args).to.deep.equal([ false ]);
+                                            });
+                                            it('Has not displayed any errors', function () {
+                                                expect(overlay.error.callCount).to.equal(0);
+                                            });
                                         });
                                     });
                                 });
@@ -587,6 +602,7 @@
                             });
                             container.register('settings.collection', {
                                 collectionName: 'Collection',
+                                comparators: 'fixtures/comparators',
                                 searchInputFields: 'fixtures/collections/searchInputFields',
                                 searchResultFields: 'fixtures/collections/searchResultFields'
                             });
@@ -613,50 +629,55 @@
                             it('Returns an object', function () {
                                 expect(page).to.be.an('object');
                             });
-                            describe('When bound to the view', function () {
+                            describe('When attached', function () {
                                 var containerElement;
                                 beforeEach(function (done) {
                                     containerElement = document.createElement('div');
-                                    page.binding(containerElement, done);
+                                    page.attaching(containerElement, done);
                                 });
-                                describe('With non-empty query', function () {
-                                    var query;
-                                    beforeEach(function () {
-                                        query = {
-                                            operator: 'AND',
-                                            children: [
-                                                {
-                                                    field: 'second',
-                                                    comparator: 'contains',
-                                                    value: 'query'
-                                                }
-                                            ]
-                                        };
-                                        page.query(query);
+                                describe('When bound to the view', function () {
+                                    beforeEach(function (done) {
+                                        page.binding(containerElement, done);
                                     });
-                                    describe('When the search form is submitted', function () {
+                                    describe('With non-empty query', function () {
+                                        var query;
                                         beforeEach(function () {
-                                            page.submit();
+                                            query = {
+                                                operator: 'AND',
+                                                children: [
+                                                    {
+                                                        field: 'second',
+                                                        comparator: 'contains',
+                                                        value: 'query'
+                                                    }
+                                                ]
+                                            };
+                                            page.query(query);
                                         });
-                                        it('Calls the specified search service with the given query', function () {
-                                            sinon.assert.calledOnce(searchService);
-                                            sinon.assert.calledWith(searchService, query);
-                                        });
-                                        it('Has results that have been limited', function () {
-                                            expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
-                                            expect(page.hasResults()).to.equal(true);
-                                            expect(page.hasLimitedResults()).to.equal(true);
-                                        });
-                                        it('Is displaying results', function () {
-                                            expect(page.displayResults()).to.equal(true);
-                                        });
-                                        it('Has displayed and then hidden the loading animation', function () {
-                                            expect(overlay.loading.callCount).to.equal(2);
-                                            expect(overlay.loading.getCall(0).args).to.deep.equal([ true ]);
-                                            expect(overlay.loading.getCall(1).args).to.deep.equal([ false ]);
-                                        });
-                                        it('Has not displayed any errors', function () {
-                                            expect(overlay.error.callCount).to.equal(0);
+                                        describe('When the search form is submitted', function () {
+                                            beforeEach(function () {
+                                                page.submit();
+                                            });
+                                            it('Calls the specified search service with the given query', function () {
+                                                sinon.assert.calledOnce(searchService);
+                                                sinon.assert.calledWith(searchService, query);
+                                            });
+                                            it('Has results that have been limited', function () {
+                                                expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
+                                                expect(page.hasResults()).to.equal(true);
+                                                expect(page.hasLimitedResults()).to.equal(true);
+                                            });
+                                            it('Is displaying results', function () {
+                                                expect(page.displayResults()).to.equal(true);
+                                            });
+                                            it('Has displayed and then hidden the loading animation', function () {
+                                                expect(overlay.loading.callCount).to.equal(2);
+                                                expect(overlay.loading.getCall(0).args).to.deep.equal([ true ]);
+                                                expect(overlay.loading.getCall(1).args).to.deep.equal([ false ]);
+                                            });
+                                            it('Has not displayed any errors', function () {
+                                                expect(overlay.error.callCount).to.equal(0);
+                                            });
                                         });
                                     });
                                 });
@@ -677,6 +698,7 @@
                         container.register('search.collection', searchService);
                         container.register('settings.collection', {
                             collectionName: 'Collection',
+                            comparators: 'fixtures/comparators',
                             inputFields: 'fixtures/collections/searchInputFields',
                             resultFields: 'fixtures/collections/searchResultFields'
                         });


### PR DESCRIPTION
+ Add `valueType` parameter in `Condition` to determine whether
  the field should be displayed.
+ Use `valueTypeIs` function to toggle display fo `value` field.
+ Add templates in `searchService` for new operators.
+ Remove `filter` call in `searchService`; this was causing empty
  values to be omitted, which caused an inconsistent result on
  browser page reload.