### PR TITLE
Improvements to query builder.

### DIFF
--- a/public/app/models/query/Group.js
+++ b/public/app/models/query/Group.js
@@ -36,6 +36,10 @@
                     return this.depth() + 1 < queryBuilder.maxDepth();
                 }.bind(this));
 
+                this.allowRemoval = ko.pureComputed(function () {
+                    return !!parentGroup;
+                }.bind(this));
+
                 this.query = ko.pureComputed(function () {
                     return {
                         operator: this.selectedOperator(),
@@ -65,7 +69,7 @@
                         }
                         childNode.parse(child);
                         return childNode;
-                    }));
+                    }.bind(this)));
                 };
 
                 this.addCondition = function () {

--- a/public/app/ui/components/search/queryBuilder/QueryBuilderComponent.less
+++ b/public/app/ui/components/search/queryBuilder/QueryBuilderComponent.less
@@ -57,6 +57,20 @@
 
     .condition {
         background-color: #fff;
+        position: relative;
+        padding-right: @padding-base-horizontal * 4;
+
+        .remove {
+            position: absolute;
+            top: @padding-base-vertical;
+            right: @padding-base-horizontal;
+        }
+
+        input,
+        select {
+            width: auto;
+            max-width: 100%;
+        }
     }
 
     input.form-control.condition-value {

--- a/public/app/ui/components/search/queryBuilder/query-builder.html
+++ b/public/app/ui/components/search/queryBuilder/query-builder.html
@@ -7,7 +7,7 @@
         <select data-bind="options: fields, optionsCaption: '', optionsText: 'labelText', optionsValue: 'key', value: selectedField" class="form-control field styled-select"></select>
         <select data-bind="options: comparators, optionsCaption: '', optionsText: 'labelText', optionsValue: 'key', value: selectedComparator" class="form-control comparator styled-select"></select>
         <input type="text" data-bind="textInput: value, event: { keypress: $component.keypressHandler }" class="form-control condition-value" />
-        <button class="btn btn-danger btn-xs pull-right" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-minus-sign"></span> Remove</button>
+        <button class="btn btn-danger btn-xs remove" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-remove"></span></button>
     </div>
 </script>
 
@@ -16,11 +16,13 @@
         <div class="group-controls">
             <select data-bind="options: operators, optionsText: 'labelText', optionsValue: 'key', value: selectedOperator" class="form-control operator styled-select"></select>
             <div class="pull-right">
-                <button class="btn btn-xs btn-success" data-bind="click: addCondition"><span class="glyphicon glyphicon-plus-sign"></span> Add Condition</button>
+                <button class="btn btn-xs btn-success" data-bind="click: addCondition"><span class="glyphicon glyphicon-plus"></span> Condition</button>
                 <!-- ko if: allowChildren -->
-                <button class="btn btn-xs btn-success" data-bind="click: addGroup"><span class="glyphicon glyphicon-plus-sign"></span> Add Group</button>
+                <button class="btn btn-xs btn-success" data-bind="click: addGroup"><span class="glyphicon glyphicon-plus"></span> Group</button>
                 <!-- /ko -->
-                <button class="btn btn-xs btn-danger" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-minus-sign"></span> Remove Group</button>
+                <!-- ko if: allowRemoval -->
+                <button class="btn btn-danger btn-xs" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-remove"></span></button>
+                <!-- /ko -->
             </div>
         </div>
         <div class="group-conditions">

--- a/public/app/ui/pages/search/search.html
+++ b/public/app/ui/pages/search/search.html
@@ -11,6 +11,9 @@
                         <!-- ko if: advancedMode -->
                         <div data-bind="component: { name: 'search/query-builder', params: { fields: inputFields, maxDepth: 3, queryObservable: query, submit: submit } }"></div>
                         <!-- /ko -->
+                        <!-- ko if: queryModified -->
+                        <p>Modified query: <code data-bind="text: queryText"></code>.</p>
+                        <!-- /ko -->
                         <!-- ko if: hasLimitedResults -->
                         <div class="alert alert-danger">
                             <strong>Please note</strong>:
@@ -49,11 +52,11 @@
         </div>
     </div>
     <!-- ko if: displayResults -->
-    <div data-bind="text: submittedQueryText" class="visible-print"></div>
     <!-- ko ifnot: hasResults -->
-    <p class="text-muted">No results found.</p>
+    <p class="text-muted">No results found for: <code data-bind="text: submittedQueryText"></code>.</p>
     <!-- /ko -->
     <!-- ko if: hasResults -->
+    <p>Displaying <strong data-bind="text: resultsCountText"></strong> for: <code data-bind="text: submittedQueryText"></code>.</p>
     <div data-bind="component: { name: 'controls/list', params: { pager: pager, sorter: sorter, modeSwitcher: modeSwitcher, searchUrlFor: searchUrlFor } }" class="text-right"></div>
     <div data-bind="component: { name: 'search/results', params: { results: displayedResults, modeSwitcher: modeSwitcher, resultFields: resultFields, start: start } }"></div>
     <!-- /ko -->

--- a/test/spec/models/query/Group.spec.js
+++ b/test/spec/models/query/Group.spec.js
@@ -30,6 +30,7 @@
                         expect(ko.isObservable(group.operators)).to.equal(true);
                         expect(ko.isObservable(group.depth)).to.equal(true);
                         expect(ko.isObservable(group.allowChildren)).to.equal(true);
+                        expect(ko.isObservable(group.allowRemoval)).to.equal(true);
                         expect(ko.isObservable(group.query)).to.equal(true);
                     });
                     it('Exposes helper methods', function () {
@@ -63,6 +64,7 @@
                         expect(ko.isObservable(group.operators)).to.equal(true);
                         expect(ko.isObservable(group.depth)).to.equal(true);
                         expect(ko.isObservable(group.allowChildren)).to.equal(true);
+                        expect(ko.isObservable(group.allowRemoval)).to.equal(true);
                         expect(ko.isObservable(group.query)).to.equal(true);
                     });
                     it('Exposes helper methods', function () {

--- a/test/spec/ui/pages/search/SearchPage.spec.js
+++ b/test/spec/ui/pages/search/SearchPage.spec.js
@@ -67,8 +67,11 @@
                                     expect(ko.isPureComputed(page.displayedResults)).to.equal(true);
                                     expect(ko.isPureComputed(page.submittedQuery)).to.equal(true);
                                     expect(ko.isPureComputed(page.submittedQueryText)).to.equal(true);
+                                    expect(ko.isPureComputed(page.queryText)).to.equal(true);
+                                    expect(ko.isPureComputed(page.queryModified)).to.equal(true);
                                     expect(ko.isPureComputed(page.heading)).to.equal(true);
                                     expect(ko.isPureComputed(page.advancedModeToggleText)).to.equal(true);
+                                    expect(ko.isPureComputed(page.resultsCountText)).to.equal(true);
                                     expect(ko.isPureComputed(page.hasResults)).to.equal(true);
                                     expect(ko.isPureComputed(page.hasLimitedResults)).to.equal(true);
                                     expect(ko.isPureComputed(page.canSubmit)).to.equal(true);
@@ -90,6 +93,7 @@
                                     expect(page.query()).to.equal(undefined);
                                 });
                                 it('Does not have any results', function () {
+                                    expect(page.resultsCountText()).to.equal('0 results');
                                     expect(page.hasResults()).to.equal(false);
                                     expect(page.hasLimitedResults()).to.equal(false);
                                 });
@@ -104,6 +108,7 @@
                                 });
                                 it('Gives the right default computed values', function () {
                                     expect(page.heading()).to.equal('Collection Search');
+                                    expect(page.resultsCountText()).to.equal('0 results');
                                     expect(page.hasResults()).to.equal(false);
                                     expect(page.hasLimitedResults()).to.equal(false);
                                 });
@@ -140,6 +145,7 @@
                                             expect(page.query()).to.equal(undefined);
                                         });
                                         it('Does not have any results', function () {
+                                            expect(page.resultsCountText()).to.equal('0 results');
                                             expect(page.hasResults()).to.equal(false);
                                             expect(page.hasLimitedResults()).to.equal(false);
                                         });
@@ -186,6 +192,7 @@
                                                     expect(page.advancedMode()).to.equal(false);
                                                 });
                                                 it('Does not have any results', function () {
+                                                    expect(page.resultsCountText()).to.equal('0 results');
                                                     expect(page.hasResults()).to.equal(false);
                                                     expect(page.hasLimitedResults()).to.equal(false);
                                                 });
@@ -210,6 +217,7 @@
                                                     expect(page.advancedMode()).to.equal(false);
                                                 });
                                                 it('Does not have any results', function () {
+                                                    expect(page.resultsCountText()).to.equal('0 results');
                                                     expect(page.hasResults()).to.equal(false);
                                                     expect(page.hasLimitedResults()).to.equal(false);
                                                 });
@@ -250,6 +258,7 @@
                                                     expect(page.advancedMode()).to.equal(false);
                                                 });
                                                 it('Does not have any results', function () {
+                                                    expect(page.resultsCountText()).to.equal('0 results');
                                                     expect(page.hasResults()).to.equal(false);
                                                     expect(page.hasLimitedResults()).to.equal(false);
                                                 });
@@ -284,6 +293,7 @@
                                                     expect(page.advancedMode()).to.equal(false);
                                                 });
                                                 it('Has results below the limit', function () {
+                                                    expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
                                                     expect(page.hasResults()).to.equal(true);
                                                     expect(page.hasLimitedResults()).to.equal(false);
                                                 });
@@ -437,6 +447,7 @@
                                             sinon.assert.calledWith(searchService, query);
                                         });
                                         it('Has results that are not limited', function () {
+                                            expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
                                             expect(page.hasResults()).to.equal(true);
                                             expect(page.hasLimitedResults()).to.equal(false);
                                         });
@@ -532,6 +543,7 @@
                                             sinon.assert.calledWith(searchService, query);
                                         });
                                         it('Has results that have been limited', function () {
+                                            expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
                                             expect(page.hasResults()).to.equal(true);
                                             expect(page.hasLimitedResults()).to.equal(true);
                                         });
@@ -627,6 +639,7 @@
                                             sinon.assert.calledWith(searchService, query);
                                         });
                                         it('Has results that have been limited', function () {
+                                            expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
                                             expect(page.hasResults()).to.equal(true);
                                             expect(page.hasLimitedResults()).to.equal(true);
                                         });
@@ -713,6 +726,7 @@
                                         sinon.assert.calledOnce(searchService);
                                     });
                                     it('Does not have any results', function () {
+                                        expect(page.resultsCountText()).to.equal('0 results');
                                         expect(page.hasResults()).to.equal(false);
                                         expect(page.hasLimitedResults()).to.equal(false);
                                     });


### PR DESCRIPTION
Fixes RWAHS-582 and RWAHS-621.

+ Improve icons and text used on "add" / "remove" buttons.
+ Display current modified query in query builder.
+ Display number of results.
+ Display query used for current search (previously only for print).
+ Don't display a "remove" button for the top-level group.
+ Add missing `bind`ing in `Group.js`.
+ Add missing `width` and `max-width` rules for condition form elements.