### PR TITLE
Allow display and printing of all (500) results.

### DIFF
--- a/public/app/models/ListPager.js
+++ b/public/app/models/ListPager.js
@@ -9,7 +9,7 @@
         function (_, ko) {
             var PAGINATION_JUMP_COUNT = 7,
                 DEFAULT_PAGE_SIZE = 12,
-                DEFAULT_AVAILABLE_PAGE_SIZES = [ 12, 24, 48, 96 ];
+                DEFAULT_AVAILABLE_PAGE_SIZES = [ 12, 24, 48, 96, 500 ];
 
             return function (sourceObservable, start, size, availablePageSizes) {
                 this.start = ko.observable(start || 0);

--- a/test/spec/models/ListPager.spec.js
+++ b/test/spec/models/ListPager.spec.js
@@ -39,7 +39,7 @@
                         it('Has the correct default initial state', function () {
                             expect(pager.start()).to.equal(0);
                             expect(pager.pageSize()).to.equal(12);
-                            expect(pager.availablePageSizes()).to.deep.equal([ 12, 24, 48, 96 ]);
+                            expect(pager.availablePageSizes()).to.deep.equal([ 12, 24, 48, 96, 500 ]);
                             expect(pager.fullResultsCount()).to.equal(500);
                             expect(pager.pageCount()).to.equal(42);
                             expect(pager.pageNumber()).to.equal(0);


### PR DESCRIPTION
Fixes RWAHS-620.

Simple solution to the problem that users want to print all of the given results.  Since the results are limited in the call to the API to 500 maximum, simply giving the option of displaying up to 500 results ensures they are all displayed.