### PR TITLE
Provide operator switch in basic search mode.

### DIFF
--- a/public/app/ui/components/search/basic/BasicSearchComponent.less
+++ b/public/app/ui/components/search/basic/BasicSearchComponent.less
@@ -1,0 +1,14 @@
+.basic-search {
+    .query-input {
+        width: 100%;
+
+        > div {
+            width: 100%;
+            padding-right: 80px;
+        }
+
+        select {
+            width: 80px;
+        }
+    }
+}

--- a/public/app/ui/components/search/basic/basic-search.html
+++ b/public/app/ui/components/search/basic/basic-search.html
@@ -1,6 +1,14 @@
 <section class="basic-search">
     <div class="form-group">
-        <input placeholder="Search" class="form-control" data-bind="textInput: searchText, attr: { placeholder: placeholder }" />
+        <div class="input-group query-input">
+            <div>
+                <input placeholder="Search" class="form-control" data-bind="textInput: searchText, attr: { placeholder: placeholder }" />
+            </div>
+            <select class="form-control styled-select" data-bind="value: operator">
+                <option value="AND">AND</option>
+                <option value="OR">OR</option>
+            </select>
+        </div>
     </div>
     <!-- ko if: displayFieldSwitch -->
     <div class="form-group">

--- a/public/app/util/convertBasicSearch.js
+++ b/public/app/util/convertBasicSearch.js
@@ -6,9 +6,10 @@
             'lodash'
         ],
         function (_) {
-            return function (field, text) {
+            return function (field, text, operator) {
+                console.log('convertBasicSearch with operator = ' + operator);
                 return text.length === 0 ? undefined : {
-                    operator: 'AND',
+                    operator: operator || 'AND',
                     children: _.map(
                         text.split(/\s+/),
                         function (term) {

--- a/public/less/main.less
+++ b/public/less/main.less
@@ -59,6 +59,7 @@
 
 // Component styles
 @import "../app/ui/components/controls/ListControlsComponent.less";
+@import "../app/ui/components/search/basic/BasicSearchComponent.less";
 @import "../app/ui/components/search/queryBuilder/QueryBuilderComponent.less";
 @import "../app/ui/components/search/quick/QuickSearchComponent.less";
 @import "../app/ui/components/search/results/SearchResultsComponent.less";

--- a/test/spec/ui/components/search/basic/BasicSearchComponent.spec.js
+++ b/test/spec/ui/components/search/basic/BasicSearchComponent.spec.js
@@ -34,6 +34,7 @@
                             });
                             it('Exposes the correct observables and computed observables', function () {
                                 expect(ko.isObservable(component.searchText)).to.equal(true);
+                                expect(ko.isObservable(component.operator)).to.equal(true);
                                 expect(ko.isPureComputed(component.displayedInputFields)).to.equal(true);
                                 expect(ko.isPureComputed(component.displayFieldSwitch)).to.equal(true);
                                 expect(ko.isPureComputed(component.selectedSearchField)).to.equal(true);
@@ -47,6 +48,9 @@
                             });
                             it('Sets the correct default search text', function () {
                                 expect(component.searchText()).to.equal('');
+                            });
+                            it('Sets the correct default operator', function () {
+                                expect(component.operator()).to.equal('AND');
                             });
                             it('Sets the input fields', function () {
                                 expect(component.displayedInputFields()).to.have.length(2); // see fixtures/collections/searchInputFields.js
@@ -100,6 +104,23 @@
                                         ]
                                     });
                                 });
+                                describe('When the operator is changed', function () {
+                                    beforeEach(function () {
+                                        component.operator('OR');
+                                    });
+                                    it('Sets the value of the query observable correctly', function () {
+                                        expect(query()).to.deep.equal({
+                                            operator: 'OR',
+                                            children: [
+                                                {
+                                                    field: 'first',
+                                                    comparator: 'contains',
+                                                    value: 'query'
+                                                }
+                                            ]
+                                        });
+                                    });
+                                });
                             });
                             describe('With non-empty search text containing multiple words', function () {
                                 beforeEach(function () {
@@ -126,6 +147,33 @@
                                                 value: 'query'
                                             }
                                         ]
+                                    });
+                                });
+                                describe('When the operator is changed', function () {
+                                    beforeEach(function () {
+                                        component.operator('OR');
+                                    });
+                                    it('Sets the value of the query observable correctly', function () {
+                                        expect(query()).to.deep.equal({
+                                            operator: 'OR',
+                                            children: [
+                                                {
+                                                    field: 'first',
+                                                    comparator: 'contains',
+                                                    value: 'multiple'
+                                                },
+                                                {
+                                                    field: 'first',
+                                                    comparator: 'contains',
+                                                    value: 'word'
+                                                },
+                                                {
+                                                    field: 'first',
+                                                    comparator: 'contains',
+                                                    value: 'query'
+                                                }
+                                            ]
+                                        });
                                     });
                                 });
                             });
@@ -161,6 +209,7 @@
                             });
                             it('Exposes the correct observables and computed observables', function () {
                                 expect(ko.isObservable(component.searchText)).to.equal(true);
+                                expect(ko.isObservable(component.operator)).to.equal(true);
                                 expect(ko.isPureComputed(component.displayedInputFields)).to.equal(true);
                                 expect(ko.isPureComputed(component.displayFieldSwitch)).to.equal(true);
                                 expect(ko.isPureComputed(component.selectedSearchField)).to.equal(true);
@@ -174,6 +223,9 @@
                             });
                             it('Sets the correct default search text', function () {
                                 expect(component.searchText()).to.equal('foo bar');
+                            });
+                            it('Sets the correct default operator', function () {
+                                expect(component.operator()).to.equal('AND');
                             });
                             it('Sets the input fields', function () {
                                 expect(component.displayedInputFields()).to.have.length(2); // see fixtures/collections/searchInputFields.js
@@ -222,6 +274,7 @@
                             });
                             it('Exposes the correct observables and computed observables', function () {
                                 expect(ko.isObservable(component.searchText)).to.equal(true);
+                                expect(ko.isObservable(component.operator)).to.equal(true);
                                 expect(ko.isPureComputed(component.displayedInputFields)).to.equal(true);
                                 expect(ko.isPureComputed(component.displayFieldSwitch)).to.equal(true);
                                 expect(ko.isPureComputed(component.selectedSearchField)).to.equal(true);
@@ -235,6 +288,9 @@
                             });
                             it('Sets the correct default search text', function () {
                                 expect(component.searchText()).to.equal('foo');
+                            });
+                            it('Sets the correct default operator', function () {
+                                expect(component.operator()).to.equal('AND');
                             });
                             it('Sets the input fields', function () {
                                 expect(component.displayedInputFields()).to.have.length(2); // see fixtures/collections/searchInputFields.js
@@ -300,6 +356,23 @@
                                         ]
                                     });
                                 });
+                                describe('When the operator is changed', function () {
+                                    beforeEach(function () {
+                                        component.operator('OR');
+                                    });
+                                    it('Sets the value of the query observable correctly', function () {
+                                        expect(query()).to.deep.equal({
+                                            operator: 'OR',
+                                            children: [
+                                                {
+                                                    field: 'only',
+                                                    comparator: 'contains',
+                                                    value: 'query'
+                                                }
+                                            ]
+                                        });
+                                    });
+                                });
                             });
                             describe('With non-empty search text containing multiple words', function () {
                                 beforeEach(function () {
@@ -325,6 +398,33 @@
                                                 value: 'query'
                                             }
                                         ]
+                                    });
+                                });
+                                describe('When the operator is changed', function () {
+                                    beforeEach(function () {
+                                        component.operator('OR');
+                                    });
+                                    it('Sets the value of the query observable correctly', function () {
+                                        expect(query()).to.deep.equal({
+                                            operator: 'OR',
+                                            children: [
+                                                {
+                                                    field: 'only',
+                                                    comparator: 'contains',
+                                                    value: 'multiple'
+                                                },
+                                                {
+                                                    field: 'only',
+                                                    comparator: 'contains',
+                                                    value: 'word'
+                                                },
+                                                {
+                                                    field: 'only',
+                                                    comparator: 'contains',
+                                                    value: 'query'
+                                                }
+                                            ]
+                                        });
                                     });
                                 });
                             });

--- a/test/spec/util/convertBasicSearch.spec.js
+++ b/test/spec/util/convertBasicSearch.spec.js
@@ -13,128 +13,257 @@
                 it('Defines a function', function () {
                     expect(convertBasicSearch).to.be.a('function');
                 });
-                describe('When invoked with an empty string', function () {
-                    it('Returns undefined', function () {
-                        expect(convertBasicSearch('field', '')).to.equal(undefined);
+                describe('When invoked without supplying an operator', function () {
+                    describe('When invoked with an empty string', function () {
+                        it('Returns undefined', function () {
+                            expect(convertBasicSearch('field', '')).to.equal(undefined);
+                        });
                     });
-                });
-                describe('When invoked with a string consisting of only whitespace', function () {
-                    it('Returns the correct query', function () {
-                        // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
-                        // text is `split` on any sequence of whitespace, which here gives an empty string from the
-                        // start of the search text and another empty string from the end of the search text.
-                        expect(convertBasicSearch('field', '   ')).to.deep.equal({
-                            operator: 'AND',
-                            children: [
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: ''
-                                },
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: ''
-                                }
-                            ]
+                    describe('When invoked with a string consisting of only whitespace', function () {
+                        it('Returns the correct query', function () {
+                            // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
+                            // text is `split` on any sequence of whitespace, which here gives an empty string from the
+                            // start of the search text and another empty string from the end of the search text.
+                            expect(convertBasicSearch('field', '   ')).to.deep.equal({
+                                operator: 'AND',
+                                children: [
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    }
+                                ]
+                            });
+                        });
+                    });
+                    describe('When invoked with a single word', function () {
+                        it('Returns the correct query', function () {
+                            expect(convertBasicSearch('field', 'xyzzy')).to.deep.equal({
+                                operator: 'AND',
+                                children: [
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'xyzzy'
+                                    }
+                                ]
+                            });
+                        });
+                    });
+                    describe('When invoked with a single word with extraneous whitespace', function () {
+                        it('Returns the correct query', function () {
+                            // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
+                            // text is `split` on any sequence of whitespace, which here gives an empty string from the
+                            // start of the search text and another empty string from the end of the search text.
+                            expect(convertBasicSearch('field', '  foo  ')).to.deep.equal({
+                                operator: 'AND',
+                                children: [
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'foo'
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    }
+                                ]
+                            });
+                        });
+                    });
+                    describe('When invoked with a multi-word string', function () {
+                        it('Returns the correct query', function () {
+                            expect(convertBasicSearch('field', 'quux xyzzy baz')).to.deep.equal({
+                                operator: 'AND',
+                                children: [
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'quux'
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'xyzzy'
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'baz'
+                                    }
+                                ]
+                            });
+                        });
+                    });
+                    describe('When invoked with a multi-word string with extraneous whitespace', function () {
+                        it('Returns the correct query', function () {
+                            // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
+                            // text is `split` on any sequence of whitespace, which here gives an empty string from the
+                            // start of the search text and another empty string from the end of the search text.  Internal
+                            // sequences of whitespace are collapsed normally.
+                            expect(convertBasicSearch('field', '  forty    two ')).to.deep.equal({
+                                operator: 'AND',
+                                children: [
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'forty'
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'two'
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    }
+                                ]
+                            });
                         });
                     });
                 });
-                describe('When invoked with a single word', function () {
-                    it('Returns the correct query', function () {
-                        expect(convertBasicSearch('field', 'xyzzy')).to.deep.equal({
-                            operator: 'AND',
-                            children: [
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: 'xyzzy'
-                                }
-                            ]
+                describe('When invoked with an operator', function () {
+                    describe('When invoked with an empty string', function () {
+                        it('Returns undefined', function () {
+                            expect(convertBasicSearch('field', '', 'OR')).to.equal(undefined);
                         });
                     });
-                });
-                describe('When invoked with a single word with extraneous whitespace', function () {
-                    it('Returns the correct query', function () {
-                        // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
-                        // text is `split` on any sequence of whitespace, which here gives an empty string from the
-                        // start of the search text and another empty string from the end of the search text.
-                        expect(convertBasicSearch('field', '  foo  ')).to.deep.equal({
-                            operator: 'AND',
-                            children: [
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: ''
-                                },
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: 'foo'
-                                },
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: ''
-                                }
-                            ]
+                    describe('When invoked with a string consisting of only whitespace', function () {
+                        it('Returns the correct query', function () {
+                            // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
+                            // text is `split` on any sequence of whitespace, which here gives an empty string from the
+                            // start of the search text and another empty string from the end of the search text.
+                            expect(convertBasicSearch('field', '   ', 'OR')).to.deep.equal({
+                                operator: 'OR',
+                                children: [
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    }
+                                ]
+                            });
                         });
                     });
-                });
-                describe('When invoked with a multi-word string', function () {
-                    it('Returns the correct query', function () {
-                        expect(convertBasicSearch('field', 'quux xyzzy baz')).to.deep.equal({
-                            operator: 'AND',
-                            children: [
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: 'quux'
-                                },
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: 'xyzzy'
-                                },
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: 'baz'
-                                }
-                            ]
+                    describe('When invoked with a single word', function () {
+                        it('Returns the correct query', function () {
+                            expect(convertBasicSearch('field', 'xyzzy', 'OR')).to.deep.equal({
+                                operator: 'OR',
+                                children: [
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'xyzzy'
+                                    }
+                                ]
+                            });
                         });
                     });
-                });
-                describe('When invoked with a multi-word string with extraneous whitespace', function () {
-                    it('Returns the correct query', function () {
-                        // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
-                        // text is `split` on any sequence of whitespace, which here gives an empty string from the
-                        // start of the search text and another empty string from the end of the search text.  Internal
-                        // sequences of whitespace are collapsed normally.
-                        expect(convertBasicSearch('field', '  forty    two ')).to.deep.equal({
-                            operator: 'AND',
-                            children: [
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: ''
-                                },
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: 'forty'
-                                },
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: 'two'
-                                },
-                                {
-                                    field: 'field',
-                                    comparator: 'contains',
-                                    value: ''
-                                }
-                            ]
+                    describe('When invoked with a single word with extraneous whitespace', function () {
+                        it('Returns the correct query', function () {
+                            // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
+                            // text is `split` on any sequence of whitespace, which here gives an empty string from the
+                            // start of the search text and another empty string from the end of the search text.
+                            expect(convertBasicSearch('field', '  foo  ', 'OR')).to.deep.equal({
+                                operator: 'OR',
+                                children: [
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'foo'
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    }
+                                ]
+                            });
+                        });
+                    });
+                    describe('When invoked with a multi-word string', function () {
+                        it('Returns the correct query', function () {
+                            expect(convertBasicSearch('field', 'quux xyzzy baz', 'OR')).to.deep.equal({
+                                operator: 'OR',
+                                children: [
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'quux'
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'xyzzy'
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'baz'
+                                    }
+                                ]
+                            });
+                        });
+                    });
+                    describe('When invoked with a multi-word string with extraneous whitespace', function () {
+                        it('Returns the correct query', function () {
+                            // This test documents a slightly strange (but not easily avoidable) behaviour.  The search
+                            // text is `split` on any sequence of whitespace, which here gives an empty string from the
+                            // start of the search text and another empty string from the end of the search text.  Internal
+                            // sequences of whitespace are collapsed normally.
+                            expect(convertBasicSearch('field', '  forty    two ', 'OR')).to.deep.equal({
+                                operator: 'OR',
+                                children: [
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'forty'
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: 'two'
+                                    },
+                                    {
+                                        field: 'field',
+                                        comparator: 'contains',
+                                        value: ''
+                                    }
+                                ]
+                            });
                         });
                     });
                 });


### PR DESCRIPTION
Fixes RWAHS-633.

+ Display an operator (AND/OR) switch.
+ Pass selected operator back to `convertBasicSearch`.
+ Use correct operator when parsing existing query.
+ Add new stylesheet to `main.less`.