### PR TITLE
Link to shop search

### DIFF
--- a/public/app/config/env/development.js
+++ b/public/app/config/env/development.js
@@ -30,13 +30,16 @@
             return function () {
                 container.register('options.service', options);
                 container.register('options.shop', {
-                    baseUrl: {
-                        digitalPhotographs: 'https://staging-shop.histwest.org.au/index.php/photographs/digital-photograph.html'
+                    baseUrl: 'https://staging-shop.histwest.org.au/index.php/',
+                    path: {
+                        search: 'catalogsearch/result/',
+                        digitalPhotographs: 'photographs/digital-photograph.html'
                     }
                 });
                 container.register('options.providence', {
-                    baseUrl: {
-                        objects: 'https://staging-collections.histwest.org.au/index.php/editor/objects/ObjectEditor/Summary/'
+                    baseUrl: 'https://staging-collections.histwest.org.au/index.php/',
+                    path: {
+                        objects: 'editor/objects/ObjectEditor/Summary/'
                     }
                 });
 

--- a/public/app/config/env/production.js
+++ b/public/app/config/env/production.js
@@ -31,13 +31,16 @@
                 container.register('options.service', options);
                 container.register('options.shop', {
                     // TODO Disabled until the shop goes live.
-                    // baseUrl: {
-                    //     digitalPhotographs: 'https://shop.histwest.org.au/index.php/photographs/digital-photograph.html'
+                    // baseUrl: 'https://shop.histwest.org.au/index.php/',
+                    // path: {
+                    //     search: 'catalogsearch/result/',
+                    //     digitalPhotographs: 'photographs/digital-photograph.html'
                     // }
                 });
                 container.register('options.providence', {
-                    baseUrl: {
-                        objects: 'https://collections.histwest.org.au/index.php/editor/objects/ObjectEditor/Summary/'
+                    baseUrl: 'https://collections.histwest.org.au/index.php/',
+                    path: {
+                        objects: 'editor/objects/ObjectEditor/Summary/'
                     }
                 });
 

--- a/public/app/config/env/staging.js
+++ b/public/app/config/env/staging.js
@@ -30,13 +30,16 @@
             return function () {
                 container.register('options.service', options);
                 container.register('options.shop', {
-                    baseUrl: {
-                        digitalPhotographs: 'https://staging-shop.histwest.org.au/index.php/photographs/digital-photograph.html'
+                    baseUrl: 'https://staging-shop.histwest.org.au/index.php/',
+                    path: {
+                        search: 'catalogsearch/result/',
+                        digitalPhotographs: 'photographs/digital-photograph.html'
                     }
                 });
                 container.register('options.providence', {
-                    baseUrl: {
-                        objects: 'https://staging-collections.histwest.org.au/index.php/editor/objects/ObjectEditor/Summary/'
+                    baseUrl: 'https://staging-collections.histwest.org.au/index.php/',
+                    path: {
+                        objects: 'editor/objects/ObjectEditor/Summary/'
                     }
                 });
 

--- a/public/app/config/env/uat.js
+++ b/public/app/config/env/uat.js
@@ -30,13 +30,16 @@
             return function () {
                 container.register('options.service', options);
                 container.register('options.shop', {
-                    baseUrl: {
-                        digitalPhotographs: 'https://uat-shop.histwest.org.au/index.php/photographs/digital-photograph.html'
+                    baseUrl: 'https://uat-shop.histwest.org.au/index.php/',
+                    path: {
+                        search: 'catalogsearch/result/',
+                        digitalPhotographs: 'photographs/digital-photograph.html'
                     }
                 });
                 container.register('options.providence', {
-                    baseUrl: {
-                        objects: 'https://uat-collections.histwest.org.au/index.php/editor/objects/ObjectEditor/Summary/'
+                    baseUrl: 'https://uat-collections.histwest.org.au/index.php/',
+                    path: {
+                        objects: 'editor/objects/ObjectEditor/Summary/'
                     }
                 });
 

--- a/public/app/models/query/Group.js
+++ b/public/app/models/query/Group.js
@@ -36,6 +36,10 @@
                     return this.depth() + 1 < queryBuilder.maxDepth();
                 }.bind(this));
 
+                this.allowRemoval = ko.pureComputed(function () {
+                    return !!parentGroup;
+                }.bind(this));
+
                 this.query = ko.pureComputed(function () {
                     return {
                         operator: this.selectedOperator(),
@@ -65,7 +69,7 @@
                         }
                         childNode.parse(child);
                         return childNode;
-                    }));
+                    }.bind(this)));
                 };
 
                 this.addCondition = function () {

--- a/public/app/ui/components/search/queryBuilder/QueryBuilderComponent.less
+++ b/public/app/ui/components/search/queryBuilder/QueryBuilderComponent.less
@@ -57,6 +57,20 @@
 
     .condition {
         background-color: #fff;
+        position: relative;
+        padding-right: @padding-base-horizontal * 4;
+
+        .remove {
+            position: absolute;
+            top: @padding-base-vertical;
+            right: @padding-base-horizontal;
+        }
+
+        input,
+        select {
+            width: auto;
+            max-width: 100%;
+        }
     }
 
     input.form-control.condition-value {

--- a/public/app/ui/components/search/queryBuilder/query-builder.html
+++ b/public/app/ui/components/search/queryBuilder/query-builder.html
@@ -7,7 +7,7 @@
         <select data-bind="options: fields, optionsCaption: '', optionsText: 'labelText', optionsValue: 'key', value: selectedField" class="form-control field styled-select"></select>
         <select data-bind="options: comparators, optionsCaption: '', optionsText: 'labelText', optionsValue: 'key', value: selectedComparator" class="form-control comparator styled-select"></select>
         <input type="text" data-bind="textInput: value, event: { keypress: $component.keypressHandler }" class="form-control condition-value" />
-        <button class="btn btn-danger btn-xs pull-right" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-minus-sign"></span> Remove</button>
+        <button class="btn btn-danger btn-xs remove" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-remove"></span></button>
     </div>
 </script>
 
@@ -16,11 +16,13 @@
         <div class="group-controls">
             <select data-bind="options: operators, optionsText: 'labelText', optionsValue: 'key', value: selectedOperator" class="form-control operator styled-select"></select>
             <div class="pull-right">
-                <button class="btn btn-xs btn-success" data-bind="click: addCondition"><span class="glyphicon glyphicon-plus-sign"></span> Add Condition</button>
+                <button class="btn btn-xs btn-success" data-bind="click: addCondition"><span class="glyphicon glyphicon-plus"></span> Condition</button>
                 <!-- ko if: allowChildren -->
-                <button class="btn btn-xs btn-success" data-bind="click: addGroup"><span class="glyphicon glyphicon-plus-sign"></span> Add Group</button>
+                <button class="btn btn-xs btn-success" data-bind="click: addGroup"><span class="glyphicon glyphicon-plus"></span> Group</button>
                 <!-- /ko -->
-                <button class="btn btn-xs btn-danger" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-minus-sign"></span> Remove Group</button>
+                <!-- ko if: allowRemoval -->
+                <button class="btn btn-danger btn-xs" data-bind="click: $parent.removeChild"><span class="glyphicon glyphicon-remove"></span></button>
+                <!-- /ko -->
             </div>
         </div>
         <div class="group-conditions">

--- a/public/app/ui/pages/detail/DetailPage.js
+++ b/public/app/ui/pages/detail/DetailPage.js
@@ -41,12 +41,12 @@
 
                 this.shopUrl = ko.pureComputed(function () {
                     var idno = this.idno();
-                    return idno && shop.baseUrl && shop.baseUrl.digitalPhotographs && context.params.type === 'photographs' ?
-                        (shop.baseUrl.digitalPhotographs + '?idno=' + idno) : undefined;
+                    return idno && shop.baseUrl && shop.path && shop.path.digitalPhotographs && context.params.type === 'photographs' ?
+                        (shop.baseUrl + shop.path.digitalPhotographs + '?idno=' + idno) : undefined;
                 }.bind(this));
 
                 this.curatorUrl = ko.pureComputed(function () {
-                    return providence.baseUrl.objects + 'object_id/' + context.params.id;
+                    return providence.baseUrl + providence.path.objects + 'object_id/' + context.params.id;
                 }.bind(this));
 
                 this.attaching = function (element, callback) {

--- a/public/app/ui/pages/search/SearchPage.js
+++ b/public/app/ui/pages/search/SearchPage.js
@@ -146,7 +146,7 @@
                     if (!shopOptions) {
                         return undefined;
                     }
-                    return shopOptions.baseUrl + shopOptions.path.search + '?q=' + _.map(submittedQuery().children, 'value').join('+');
+                    return shopOptions.baseUrl + shopOptions.path.search + '?q=' + _(submittedQuery().children).map('value').filter().join('+');
                 });
 
                 this.shopSearchText = ko.pureComputed(function () {

--- a/public/app/ui/pages/search/SearchPage.js
+++ b/public/app/ui/pages/search/SearchPage.js
@@ -136,6 +136,23 @@
                     return !!this.query() && this.query().children.length > 0;
                 }.bind(this));
 
+                this.shopBaseUrl = ko.pureComputed(function () {
+                    var shopOptions = container.resolve('options.shop');
+                    return shopOptions ? shopOptions.baseUrl : undefined;
+                });
+
+                this.shopSearchUrl = ko.pureComputed(function () {
+                    var shopOptions = container.resolve('options.shop');
+                    if (!shopOptions) {
+                        return undefined;
+                    }
+                    return shopOptions.baseUrl + shopOptions.path.search + '?q=' + _.map(submittedQuery().children, 'value').join('+');
+                });
+
+                this.shopSearchText = ko.pureComputed(function () {
+                    return _.map(submittedQuery().children, 'value').join(' ');
+                });
+
                 this.attaching = function (element, callback) {
                     require(
                         [

--- a/public/app/ui/pages/search/search.html
+++ b/public/app/ui/pages/search/search.html
@@ -11,6 +11,9 @@
                         <!-- ko if: advancedMode -->
                         <div data-bind="component: { name: 'search/query-builder', params: { fields: inputFields, maxDepth: 3, queryObservable: query, submit: submit } }"></div>
                         <!-- /ko -->
+                        <!-- ko if: queryModified -->
+                        <p>Modified query: <code data-bind="text: queryText"></code>.</p>
+                        <!-- /ko -->
                         <!-- ko if: hasLimitedResults -->
                         <div class="alert alert-danger">
                             <strong>Please note</strong>:
@@ -49,11 +52,11 @@
         </div>
     </div>
     <!-- ko if: displayResults -->
-    <div data-bind="text: submittedQueryText" class="visible-print"></div>
     <!-- ko ifnot: hasResults -->
-    <p class="text-muted">No results found.</p>
+    <p class="text-muted">No results found for: <code data-bind="text: submittedQueryText"></code>.</p>
     <!-- /ko -->
     <!-- ko if: hasResults -->
+    <p>Displaying <strong data-bind="text: resultsCountText"></strong> for: <code data-bind="text: submittedQueryText"></code>.</p>
     <div data-bind="component: { name: 'controls/list', params: { pager: pager, sorter: sorter, modeSwitcher: modeSwitcher, searchUrlFor: searchUrlFor } }" class="text-right"></div>
     <div data-bind="component: { name: 'search/results', params: { results: displayedResults, modeSwitcher: modeSwitcher, resultFields: resultFields, start: start } }"></div>
     <!-- /ko -->

--- a/public/app/ui/pages/search/search.html
+++ b/public/app/ui/pages/search/search.html
@@ -53,10 +53,23 @@
     </div>
     <!-- ko if: displayResults -->
     <!-- ko ifnot: hasResults -->
-    <p class="text-muted">No results found for: <code data-bind="text: submittedQueryText"></code>.</p>
+    <p class="text-muted">
+        No results found for: <code data-bind="text: submittedQueryText"></code>.
+    </p>
     <!-- /ko -->
     <!-- ko if: hasResults -->
-    <p>Displaying <strong data-bind="text: resultsCountText"></strong> for: <code data-bind="text: submittedQueryText"></code>.</p>
+    <p>
+        Displaying <strong data-bind="text: resultsCountText"></strong> for:
+        <code data-bind="text: submittedQueryText"></code>.
+    </p>
+    <!-- /ko -->
+    <!-- ko if: shopBaseUrl -->
+    <p>
+        The <a href="#" target="_blank" data-bind="attr: { href: shopBaseUrl }">shop</a> may have results related to
+        <a href="#" target="_blank" data-bind="text: shopSearchText, attr: { href: shopSearchUrl }">your query</a>.
+    </p>
+    <!-- /ko -->
+    <!-- ko if: hasResults -->
     <div data-bind="component: { name: 'controls/list', params: { pager: pager, sorter: sorter, modeSwitcher: modeSwitcher, searchUrlFor: searchUrlFor } }" class="text-right"></div>
     <div data-bind="component: { name: 'search/results', params: { results: displayedResults, modeSwitcher: modeSwitcher, resultFields: resultFields, start: start } }"></div>
     <!-- /ko -->

--- a/test/spec/models/query/Group.spec.js
+++ b/test/spec/models/query/Group.spec.js
@@ -30,6 +30,7 @@
                         expect(ko.isObservable(group.operators)).to.equal(true);
                         expect(ko.isObservable(group.depth)).to.equal(true);
                         expect(ko.isObservable(group.allowChildren)).to.equal(true);
+                        expect(ko.isObservable(group.allowRemoval)).to.equal(true);
                         expect(ko.isObservable(group.query)).to.equal(true);
                     });
                     it('Exposes helper methods', function () {
@@ -63,6 +64,7 @@
                         expect(ko.isObservable(group.operators)).to.equal(true);
                         expect(ko.isObservable(group.depth)).to.equal(true);
                         expect(ko.isObservable(group.allowChildren)).to.equal(true);
+                        expect(ko.isObservable(group.allowRemoval)).to.equal(true);
                         expect(ko.isObservable(group.query)).to.equal(true);
                     });
                     it('Exposes helper methods', function () {

--- a/test/spec/ui/pages/detail/DetailPage.spec.js
+++ b/test/spec/ui/pages/detail/DetailPage.spec.js
@@ -27,13 +27,15 @@
                             description: '<p>Rich text <strong>description</strong>.</p>'
                         });
                         container.register('options.shop', {
-                            baseUrl: {
-                                digitalPhotographs: 'https://fake.shop/photographs'
+                            baseUrl: 'https://fake.shop/',
+                            path: {
+                                digitalPhotographs: 'photographs'
                             }
                         });
                         container.register('options.providence', {
-                            baseUrl: {
-                                objects: 'https://fake.domain/editor/objects/'
+                            baseUrl: 'https://fake.domain/',
+                            path: {
+                                objects: 'editor/objects/'
                             }
                         });
                         container.register('detail.collection', detailService);
@@ -213,13 +215,15 @@
                     beforeEach(function () {
                         detailService = sinon.stub().callsArgWith(1, new Error('Service Error'));
                         container.register('options.shop', {
-                            baseUrl: {
-                                digitalPhotographs: 'https://fake.shop/photographs'
+                            baseUrl: 'https://fake.shop/',
+                            path: {
+                                digitalPhotographs: 'photographs'
                             }
                         });
                         container.register('options.providence', {
-                            baseUrl: {
-                                objects: 'https://fake.domain/editor/objects/'
+                            baseUrl: 'https://fake.domain/',
+                            path: {
+                                objects: 'editor/objects/'
                             }
                         });
                         container.register('detail.collection', detailService);
@@ -300,8 +304,9 @@
                         });
                         container.register('options.shop', {});
                         container.register('options.providence', {
-                            baseUrl: {
-                                objects: 'https://fake.domain/editor/objects/'
+                            baseUrl: 'https://fake.domain/',
+                            path: {
+                                objects: 'editor/objects/'
                             }
                         });
                         container.register('detail.collection', detailService);

--- a/test/spec/ui/pages/search/SearchPage.spec.js
+++ b/test/spec/ui/pages/search/SearchPage.spec.js
@@ -75,6 +75,10 @@
                                     expect(ko.isPureComputed(page.hasResults)).to.equal(true);
                                     expect(ko.isPureComputed(page.hasLimitedResults)).to.equal(true);
                                     expect(ko.isPureComputed(page.canSubmit)).to.equal(true);
+                                    // TODO Further tests for these computed observables; no shop details are set above.
+                                    expect(ko.isPureComputed(page.shopBaseUrl)).to.equal(true);
+                                    expect(ko.isPureComputed(page.shopSearchUrl)).to.equal(true);
+                                    expect(ko.isPureComputed(page.shopSearchText)).to.equal(true);
                                 });
                                 it('Exposes life cycle methods', function () {
                                     expect(page.attaching).to.be.a('function');

--- a/test/spec/ui/pages/search/SearchPage.spec.js
+++ b/test/spec/ui/pages/search/SearchPage.spec.js
@@ -67,8 +67,11 @@
                                     expect(ko.isPureComputed(page.displayedResults)).to.equal(true);
                                     expect(ko.isPureComputed(page.submittedQuery)).to.equal(true);
                                     expect(ko.isPureComputed(page.submittedQueryText)).to.equal(true);
+                                    expect(ko.isPureComputed(page.queryText)).to.equal(true);
+                                    expect(ko.isPureComputed(page.queryModified)).to.equal(true);
                                     expect(ko.isPureComputed(page.heading)).to.equal(true);
                                     expect(ko.isPureComputed(page.advancedModeToggleText)).to.equal(true);
+                                    expect(ko.isPureComputed(page.resultsCountText)).to.equal(true);
                                     expect(ko.isPureComputed(page.hasResults)).to.equal(true);
                                     expect(ko.isPureComputed(page.hasLimitedResults)).to.equal(true);
                                     expect(ko.isPureComputed(page.canSubmit)).to.equal(true);
@@ -90,6 +93,7 @@
                                     expect(page.query()).to.equal(undefined);
                                 });
                                 it('Does not have any results', function () {
+                                    expect(page.resultsCountText()).to.equal('0 results');
                                     expect(page.hasResults()).to.equal(false);
                                     expect(page.hasLimitedResults()).to.equal(false);
                                 });
@@ -104,6 +108,7 @@
                                 });
                                 it('Gives the right default computed values', function () {
                                     expect(page.heading()).to.equal('Collection Search');
+                                    expect(page.resultsCountText()).to.equal('0 results');
                                     expect(page.hasResults()).to.equal(false);
                                     expect(page.hasLimitedResults()).to.equal(false);
                                 });
@@ -140,6 +145,7 @@
                                             expect(page.query()).to.equal(undefined);
                                         });
                                         it('Does not have any results', function () {
+                                            expect(page.resultsCountText()).to.equal('0 results');
                                             expect(page.hasResults()).to.equal(false);
                                             expect(page.hasLimitedResults()).to.equal(false);
                                         });
@@ -186,6 +192,7 @@
                                                     expect(page.advancedMode()).to.equal(false);
                                                 });
                                                 it('Does not have any results', function () {
+                                                    expect(page.resultsCountText()).to.equal('0 results');
                                                     expect(page.hasResults()).to.equal(false);
                                                     expect(page.hasLimitedResults()).to.equal(false);
                                                 });
@@ -210,6 +217,7 @@
                                                     expect(page.advancedMode()).to.equal(false);
                                                 });
                                                 it('Does not have any results', function () {
+                                                    expect(page.resultsCountText()).to.equal('0 results');
                                                     expect(page.hasResults()).to.equal(false);
                                                     expect(page.hasLimitedResults()).to.equal(false);
                                                 });
@@ -250,6 +258,7 @@
                                                     expect(page.advancedMode()).to.equal(false);
                                                 });
                                                 it('Does not have any results', function () {
+                                                    expect(page.resultsCountText()).to.equal('0 results');
                                                     expect(page.hasResults()).to.equal(false);
                                                     expect(page.hasLimitedResults()).to.equal(false);
                                                 });
@@ -284,6 +293,7 @@
                                                     expect(page.advancedMode()).to.equal(false);
                                                 });
                                                 it('Has results below the limit', function () {
+                                                    expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
                                                     expect(page.hasResults()).to.equal(true);
                                                     expect(page.hasLimitedResults()).to.equal(false);
                                                 });
@@ -437,6 +447,7 @@
                                             sinon.assert.calledWith(searchService, query);
                                         });
                                         it('Has results that are not limited', function () {
+                                            expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
                                             expect(page.hasResults()).to.equal(true);
                                             expect(page.hasLimitedResults()).to.equal(false);
                                         });
@@ -532,6 +543,7 @@
                                             sinon.assert.calledWith(searchService, query);
                                         });
                                         it('Has results that have been limited', function () {
+                                            expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
                                             expect(page.hasResults()).to.equal(true);
                                             expect(page.hasLimitedResults()).to.equal(true);
                                         });
@@ -627,6 +639,7 @@
                                             sinon.assert.calledWith(searchService, query);
                                         });
                                         it('Has results that have been limited', function () {
+                                            expect(page.resultsCountText()).to.equal('3 results'); // 3 results defined above
                                             expect(page.hasResults()).to.equal(true);
                                             expect(page.hasLimitedResults()).to.equal(true);
                                         });
@@ -713,6 +726,7 @@
                                         sinon.assert.calledOnce(searchService);
                                     });
                                     it('Does not have any results', function () {
+                                        expect(page.resultsCountText()).to.equal('0 results');
                                         expect(page.hasResults()).to.equal(false);
                                         expect(page.hasLimitedResults()).to.equal(false);
                                     });


### PR DESCRIPTION
Fixes RWAHS-606.

Includes #87 please merge that one first.

When the shop configuration is supplied, and a search is executed, a link is provided to the shop for the same search query.

This uses only top-level terms from advanced searches, nested terms are ignored.